### PR TITLE
Fix minor typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ The usage of this function is identical to `train_test_split` but with the addit
 
 ```python
 train_test_split_molecules(
-    self.X,
-    self.y,
-    0.2,
+    smiles=smiles,
+    y=y,
+    test_size=0.2,
+    train_size=0.8,
     fingerprint="daylight_fingerprint",
     fprints_hopts={
         "minPath": 2,


### PR DESCRIPTION
This PR fixes a minor typo in the readme which said `self.X` rather than presumably `X` or simply `smiles` to be more clear about the input.

However, I think there is a potential logic issue with the function `train_test_split_molecules`. The example in the readme only specified the `test_size`. However, the function has default values for both `test_size` and `train_size` so if only one is provided, they may not sum to 1. I did a lazy fix for now and just updated the example syntax in the readme to pass both arguments. Happy to work on addressing it in this PR or in a follow up PR