### PR TITLE
Revert back to sklearn train_test split for random splitting

### DIFF
--- a/astartes/samplers/interpolation/random_split.py
+++ b/astartes/samplers/interpolation/random_split.py
@@ -1,6 +1,7 @@
-from astartes.samplers import AbstractSampler
 import numpy as np
-import random
+from sklearn.model_selection import train_test_split
+
+from astartes.samplers import AbstractSampler
 
 
 class Random(AbstractSampler):
@@ -9,5 +10,10 @@ class Random(AbstractSampler):
 
     def _sample(self):
         idx_list = list(range(len(self.X)))
-        random.Random(self.get_config("random_state", None)).shuffle(idx_list)
-        self._samples_idxs = np.array(idx_list, dtype=int)
+        train_indices, test_indices = train_test_split(
+            idx_list,
+            train_size=len(idx_list) - 1,
+            random_state=self.get_config("random_state", None),
+            shuffle=self.get_config("shuffle", True),
+        )
+        self._samples_idxs = np.array(train_indices + test_indices, dtype=int)

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -65,7 +65,7 @@ class Test_astartes(unittest.TestCase):
                     "random_state": 42,
                 },
             )
-            for elt, ans in zip(X_train.flatten(), [4, 5, 6, 1, 2, 3]):
+            for elt, ans in zip(X_train.flatten(), [4, 5, 6, 7, 8, 9]):
                 self.assertEqual(elt, ans)
 
     def test_return_indices(self):
@@ -83,7 +83,7 @@ class Test_astartes(unittest.TestCase):
                 },
                 return_indices=True,
             )
-            for elt, ans in zip(indices_train.flatten(), [1, 0]):
+            for elt, ans in zip(indices_train.flatten(), [1, 2]):
                 self.assertEqual(elt, ans)
 
 


### PR DESCRIPTION
This PR addresses issue #46. Random and sklearn use different methods to generate random splits. Since the intention is for users to substitute sklearn's `train_test` split with this one, it would be convenient to have the generated splits be identical when specifying the same random state. The behavior was not happening when using Random.shuffle()