### PR TITLE
Switch 'backend' to `train_val_test_split` instead of `train_test_split`

### DIFF
--- a/astartes/__init__.py
+++ b/astartes/__init__.py
@@ -1,5 +1,5 @@
 # convenience import to enable 'from astartes import train_test_split
-from .main import train_val_test_split, train_test_split
+from .main import train_test_split, train_val_test_split
 
 # DO NOT do this:
 # from .molecules import train_test_split_molecules

--- a/astartes/__init__.py
+++ b/astartes/__init__.py
@@ -1,5 +1,5 @@
 # convenience import to enable 'from astartes import train_test_split
-from .main import train_test_split
+from .main import train_val_test_split, train_test_split
 
 # DO NOT do this:
 # from .molecules import train_test_split_molecules

--- a/astartes/main.py
+++ b/astartes/main.py
@@ -28,13 +28,11 @@ def train_val_test_split(
     sampler_factory = SamplerFactory(sampler)
     sampler_instance = sampler_factory.get_sampler(X, y, labels, hopts)
 
-    if test_size is not None:
-        train_size = 1.0 - test_size
-
     if sampler in IMPLEMENTED_EXTRAPOLATION_SAMPLERS:
         return _extrapolative_sampling(
             sampler_instance,
             test_size,
+            val_size,
             train_size,
             return_indices,
         )
@@ -42,6 +40,7 @@ def train_val_test_split(
         return _interpolative_sampling(
             sampler_instance,
             test_size,
+            val_size,
             train_size,
             return_indices,
         )
@@ -82,89 +81,145 @@ def train_test_split(
 def _extrapolative_sampling(
     sampler_instance,
     test_size,
+    val_size,
     train_size,
     return_indices,
 ):
     # validation for extrapolative sampling
     n_test_samples = floor(len(sampler_instance.X) * test_size)
+    n_val_samples = floor(len(sampler_instance.X) * val_size)
 
     # can't break up clusters
     cluster_counter = sampler_instance.get_sorted_cluster_counter()
-    test_idxs, train_idxs = np.array([], dtype=int), np.array([], dtype=int)
+    test_idxs, val_idxs, train_idxs = (
+        np.array([], dtype=int),
+        np.array([], dtype=int),
+        np.array([], dtype=int),
+    )
     for cluster_idx, cluster_length in cluster_counter.items():
         # assemble test first
         if (len(test_idxs) + cluster_length) <= n_test_samples:  # will not overfill
             test_idxs = np.append(
                 test_idxs, sampler_instance.get_sample_idxs(cluster_length)
             )
+        if (len(val_idxs) + cluster_length) <= n_val_samples:
+            val_idxs = np.append(
+                val_idxs, sampler_instance.get_sample_idxs(cluster_length)
+            )
         else:  # then balance goes into train
             train_idxs = np.append(
                 train_idxs, sampler_instance.get_sample_idxs(cluster_length)
             )
-    _check_actual_split(train_idxs, test_idxs, train_size, test_size)
-    return _return_helper(sampler_instance, train_idxs, test_idxs, return_indices)
+    _check_actual_split(
+        train_idxs, val_idxs, test_idxs, train_size, val_size, test_size
+    )
+    return _return_helper(
+        sampler_instance, train_idxs, val_idxs, test_idxs, return_indices
+    )
 
 
 def _interpolative_sampling(
     sampler_instance,
     test_size,
+    val_size,
     train_size,
     return_indices,
 ):
+    # build test first
+    n_test_samples = floor(len(sampler_instance.X) * test_size)
+    n_val_samples = floor(len(sampler_instance.X) * val_size)
+    n_train_samples = len(sampler_instance.X) - (n_test_samples + n_val_samples)
 
-    n_train_samples = floor(len(sampler_instance.X) * train_size)
-    n_test_samples = len(sampler_instance.X) - n_train_samples
-
-    train_idxs = sampler_instance.get_sample_idxs(n_train_samples)
     test_idxs = sampler_instance.get_sample_idxs(n_test_samples)
+    val_idxs = sampler_instance.get_sample_idxs(n_val_samples)
+    train_idxs = sampler_instance.get_sample_idxs(n_train_samples)
 
-    _check_actual_split(train_idxs, test_idxs, train_size, test_size)
-    return _return_helper(sampler_instance, train_idxs, test_idxs, return_indices)
+    _check_actual_split(
+        train_idxs, val_idxs, test_idxs, train_size, val_size, test_size
+    )
+    return _return_helper(
+        sampler_instance, train_idxs, val_idxs, test_idxs, return_indices
+    )
 
 
 def _return_helper(
     sampler_instance,
     train_idxs,
+    val_idxs,
     test_idxs,
     return_indices,
 ):
     if return_indices:
-        return train_idxs, test_idxs
+        if val_idxs:
+            return train_idxs, val_idxs, test_idxs
+        else:
+            return train_idxs, test_idxs
     out = []
     X_train = sampler_instance.X[train_idxs]
     out.append(X_train)
+    if val_idxs:
+        X_val = sampler_instance.X[val_idxs]
+        out.append(X_val)
     X_test = sampler_instance.X[test_idxs]
     out.append(X_test)
 
     if sampler_instance.y is not None:
         y_train = sampler_instance.y[train_idxs]
         out.append(y_train)
+        if val_idxs:
+            y_val = sampler_instance.y[val_idxs]
+            out.append(y_val)
         y_test = sampler_instance.y[test_idxs]
         out.append(y_test)
     if sampler_instance.labels is not None:
         labels_train = sampler_instance.labels[train_idxs]
         out.append(labels_train)
+        if val_idxs:
+            labels_val = sampler_instance.labels[val_idxs]
+            out.append(labels_val)
         labels_test = sampler_instance.labels[test_idxs]
         out.append(labels_test)
     if len(sampler_instance.get_clusters()):  # true when the list has been filled
         clusters_train = sampler_instance.get_clusters()[train_idxs]
         out.append(clusters_train)
+        if val_idxs:
+            clusters_val = sampler_instance.get_clusters()[val_idxs]
+            out.append(clusters_val)
         clusters_test = sampler_instance.get_clusters()[test_idxs]
         out.append(clusters_test)
 
     return (*out,)
 
 
-def _check_actual_split(train_idxs, test_idxs, train_size, test_size):
-    actual_train_size = round(len(train_idxs) / (len(test_idxs) + len(train_idxs)), 2)
+def _check_actual_split(
+    train_idxs,
+    val_idxs,
+    test_idxs,
+    train_size,
+    val_size,
+    test_size,
+):
+    total_size = len(test_idxs) + len(val_idxs) + len(train_idxs)
+
+    actual_train_size = round(len(train_idxs) / total_size, 2)
     requested_train_size = round(train_size, 2)
-    actual_test_size = round(1.0 - actual_train_size, 2)
+
+    actual_val_size = round(len(val_idxs) / total_size, 2)
+    requested_val_size = round(val_size, 2)
+
+    actual_test_size = round(len(test_idxs) / total_size, 2)
     requested_test_size = round(test_size, 2)
+
     msg = ""
     if actual_train_size != requested_train_size:
         msg += "Requested train size of {:.2f}, got {:.2f}. ".format(
             requested_train_size,
             actual_train_size,
+        )
+    if actual_val_size != requested_val_size:
+        msg += "Requested validation size of {:.2f}, got {:.2f}. ".format(
+            requested_test_size,
+            actual_test_size,
         )
     if actual_test_size != requested_test_size:
         msg += "Requested test size of {:.2f}, got {:.2f}. ".format(

--- a/astartes/main.py
+++ b/astartes/main.py
@@ -7,9 +7,9 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
+from astartes.utils.exceptions import InvalidConfigurationError
 from astartes.utils.sampler_factory import SamplerFactory
 from astartes.utils.warnings import ImperfectSplittingWarning, NormalizationWarning
-from astartes.utils.exceptions import InvalidConfigurationError
 
 
 def train_val_test_split(

--- a/astartes/main.py
+++ b/astartes/main.py
@@ -219,7 +219,7 @@ def _check_actual_split(
     if not len(test_idxs):
         msg += " testing set empty "
     if val_size and not len(val_idxs):
-        msg += "validation set empty "
+        msg += " validation set empty "
     if msg:
         raise InvalidConfigurationError(
             "Provided data and requested split resulted in an empty set. "

--- a/astartes/molecules.py
+++ b/astartes/molecules.py
@@ -12,21 +12,63 @@ except ImportError:  # pragma: no cover
     )
 
 
-from astartes import train_test_split
+from astartes import train_test_split, train_val_test_split
+
+
+def train_val_test_split_molecules(
+    smiles: List[str],
+    y: np.array = None,
+    labels: np.array = None,
+    train_size: float = 0.8,
+    val_size: float = 0.1,
+    test_size: float = 0.1,
+    sampler: str = "random",
+    hopts: dict = {},
+    fingerprint: str = "morgan_fingerprint",
+    return_as: str = "fprint",
+    fprints_hopts: dict = {},
+):
+    X = _featurize(smiles, fingerprint, fprints_hopts)
+    return train_val_test_split(
+        X,
+        y=y,
+        labels=labels,
+        test_size=test_size,
+        val_size=val_size,
+        train_size=train_size,
+        sampler=sampler,
+        hopts=hopts,
+    )
 
 
 def train_test_split_molecules(
     smiles: List[str],
     y: np.array = None,
+    labels: np.array = None,
     train_size: float = 0.75,
     test_size: float = None,
     sampler: str = "random",
+    hopts: dict = {},
     fingerprint: str = "morgan_fingerprint",
     return_as: str = "fprint",
-    hopts: dict = {},
     fprints_hopts: dict = {},
 ):
     # turn the smiles into an input X
+    X = _featurize(smiles, fingerprint, fprints_hopts)
+
+    # call train test split with this input
+    return train_test_split(
+        X,
+        y=y,
+        labels=labels,
+        test_size=test_size,
+        train_size=train_size,
+        sampler=sampler,
+        hopts=hopts,
+    )
+
+
+def _featurize(smiles, fingerprint, fprints_hopts):
     X = []
     for smile in smiles:
         mol = Molecule(mol_smiles=smile)
@@ -36,13 +78,4 @@ def train_test_split_molecules(
             fingerprint_params=fprints_hopts,
         )
         X.append(mol.descriptor.to_numpy())
-    X = np.array(X)
-    # call train test split with this input
-    return train_test_split(
-        X,
-        y=y,
-        test_size=test_size,
-        train_size=train_size,
-        sampler=sampler,
-        hopts=hopts,
-    )
+    return np.array(X)

--- a/astartes/molecules.py
+++ b/astartes/molecules.py
@@ -18,8 +18,8 @@ from astartes import train_test_split
 def train_test_split_molecules(
     smiles: List[str],
     y: np.array = None,
-    test_size: float = 0.25,
     train_size: float = 0.75,
+    test_size: float = None,
     sampler: str = "random",
     fingerprint: str = "morgan_fingerprint",
     return_as: str = "fprint",

--- a/astartes/utils/exceptions.py
+++ b/astartes/utils/exceptions.py
@@ -9,6 +9,14 @@ class MoleculesNotInstalledError(RuntimeError):  # pragma: no cover
         super().__init__(message)
 
 
+class InvalidConfigurationError(RuntimeError):
+    """Used when user-requested split/data would not work."""
+
+    def __init__(self, message=None):
+        self.message = message
+        super().__init__(message)
+
+
 class NotImplementedError(RuntimeError):
     """Used when attempting to call a non-existent sampler."""
 

--- a/astartes/utils/warnings.py
+++ b/astartes/utils/warnings.py
@@ -7,3 +7,11 @@ class ImperfectSplittingWarning(RuntimeWarning):
     def __init__(self, message=None):
         self.message = message
         super().__init__(message)
+
+
+class NormalizationWarning(RuntimeWarning):
+    """Used when a requested split does not add to 1."""
+
+    def __init__(self, message=None):
+        self.message = message
+        super().__init__(message)

--- a/test/samplers/test_kennard_stone.py
+++ b/test/samplers/test_kennard_stone.py
@@ -72,52 +72,52 @@ class Test_kennard_stone(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.25,
-                train_size=0.75,
+                test_size=0.7,
+                train_size=0.3,
                 sampler="kennard_stone",
             )
         # test that the known arrays equal the result from above
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array([[0, 0, 0], [1, 1, 1]]),
+                np.array([[0, 1, 0]]),
+                "Train X incorrect.",
             ),
-            "Train X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[0, 1, 0]]),
+                np.array([[0, 0, 0], [1, 1, 1]]),
+                "Test X incorrect.",
             ),
-            "Test X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([1, 3]),
+                np.array([2]),
+                "Train y incorrect.",
             ),
-            "Train y incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([2]),
+                np.array([1, 3]),
+                "Test y incorrect.",
             ),
-            "Test y incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["one", "three"]),
+                np.array(["two"]),
+                "Train labels incorrect.",
             ),
-            "Train labels incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["two"]),
+                np.array(["one", "three"]),
+                "Test labels incorrect.",
             ),
-            "Test labels incorrect.",
         )
 
     def test_kennard_stone_sample_no_warning(self):
@@ -135,8 +135,8 @@ class Test_kennard_stone(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.33,
-                train_size=0.67,
+                test_size=0.67,
+                train_size=0.33,
                 sampler="kennard_stone",
             )
             self.assertFalse(

--- a/test/samplers/test_random.py
+++ b/test/samplers/test_random.py
@@ -64,8 +64,8 @@ class Test_random(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.25,
-                train_size=0.75,
+                test_size=0.75,
+                train_size=0.25,
                 sampler="random",
                 hopts={
                     "random_state": 42,
@@ -75,44 +75,44 @@ class Test_random(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array([[0, 1, 0], [1, 1, 1]]),
+                np.array([[0, 0, 0]]),
+                "Train X incorrect.",
             ),
-            "Train X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[0, 0, 0]]),
+                np.array([[0, 1, 0], [1, 1, 1]]),
+                "Test X incorrect.",
             ),
-            "Test X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([2, 3]),
+                np.array([1]),
+                "Train y incorrect.",
             ),
-            "Train y incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([1]),
+                np.array([2, 3]),
+                "Test y incorrect.",
             ),
-            "Test y incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["two", "three"]),
+                np.array(["one"]),
+                "Train labels incorrect.",
             ),
-            "Train labels incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["one"]),
+                np.array(["two", "three"]),
+                "Test labels incorrect.",
             ),
-            "Test labels incorrect.",
         )
 
     def test_random_sample_no_warning(self):
@@ -130,8 +130,8 @@ class Test_random(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.33,
-                train_size=0.67,
+                test_size=0.67,
+                train_size=0.33,
                 sampler="random",
                 hopts={
                     "random_state": 42,

--- a/test/samplers/test_sphere_exclusion.py
+++ b/test/samplers/test_sphere_exclusion.py
@@ -63,58 +63,69 @@ class Test_sphere_exclusion(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array([[0, 0, 0, 0, 0], [1, 0, 0, 0, 0], [1, 1, 0, 0, 0]]),
+                np.array(
+                    [
+                        [1, 0, 0, 0, 0],
+                        [1, 1, 0, 0, 0],
+                        [1, 1, 1, 0, 0],
+                        [1, 1, 1, 1, 0],
+                    ]
+                ),
+                "Train X incorrect.",
             ),
-            "Train X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]),
+                np.array(
+                    [
+                        [0, 0, 0, 0, 0],
+                    ]
+                ),
+                "Test X incorrect.",
             ),
-            "Test X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([1, 2, 3]),
+                np.array([2, 3, 4, 5]),
+                "Train y incorrect.",
             ),
-            "Train y incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([4, 5]),
+                np.array([1]),
+                "Test y incorrect.",
             ),
-            "Test y incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["one", "two", "three"]),
+                np.array(["two", "three", "four", "five"]),
+                "Train labels incorrect.",
             ),
-            "Train labels incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["four", "five"]),
+                np.array(["one"]),
+                "Test labels incorrect.",
             ),
-            "Test labels incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 clusters_train,
-                np.array([2, 1, 1]),
+                np.array([1, 1, 0, 0]),
+                "Train clusters incorrect.",
             ),
-            "Train clusters incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 clusters_test,
-                np.array([0, 0]),
+                np.array([2]),
+                "Test clusters incorrect.",
             ),
-            "Test clusters incorrect.",
         )
 
     def test_sphereexclusion(self):

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -361,6 +361,25 @@ class Test_astartes(unittest.TestCase):
             for elt, ans in zip(indices_train.flatten(), [2, 0]):
                 self.assertEqual(elt, ans)
 
+    def test_return_indices_with_validation(self):
+        """ """
+        with self.assertWarns(ImperfectSplittingWarning):
+            (indices_train, indices_val, indices_test,) = train_val_test_split(
+                np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                labels=np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                test_size=0.33,
+                val_size=0.33,
+                train_size=0.33,
+                sampler="random",
+                hopts={
+                    "random_state": 42,
+                },
+                return_indices=True,
+            )
+            for elt, ans in zip(indices_val.flatten(), [8, 2]):
+                self.assertEqual(elt, ans)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -187,12 +187,13 @@ class Test_astartes(unittest.TestCase):
                     test_size=None,
                 )
         with self.subTest("val_size w/ valid test_size"):
-            train_val_test_split(
-                self.X,
-                train_size=None,
-                val_size=0.4,
-                test_size=0.6,
-            )
+            with self.assertWarns(ImperfectSplittingWarning):
+                train_val_test_split(
+                    self.X,
+                    train_size=None,
+                    val_size=0.4,
+                    test_size=0.6,
+                )
         with self.subTest("val_size w/ invalid test_size"):
             with self.assertRaises(RuntimeError):
                 train_val_test_split(
@@ -202,12 +203,13 @@ class Test_astartes(unittest.TestCase):
                     test_size=2,
                 )
         with self.subTest("val_size w/ valid train_size"):
-            train_val_test_split(
-                self.X,
-                train_size=0.2,
-                val_size=0.4,
-                test_size=None,
-            )
+            with self.assertWarns(ImperfectSplittingWarning):
+                train_val_test_split(
+                    self.X,
+                    train_size=0.2,
+                    val_size=0.4,
+                    test_size=None,
+                )
         with self.subTest("val_size w/ invalid train_size"):
             with self.assertRaises(RuntimeError):
                 train_val_test_split(

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -5,8 +5,7 @@ import warnings
 
 import numpy as np
 
-from astartes import train_test_split
-from astartes import train_val_test_split
+from astartes import train_test_split, train_val_test_split
 from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import warnings
+import functools
 
 import numpy as np
 
@@ -10,7 +11,7 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
-from astartes.utils.exceptions import NotImplementedError
+from astartes.utils.exceptions import NotImplementedError, InvalidConfigurationError
 from astartes.utils.warnings import ImperfectSplittingWarning, NormalizationWarning
 
 
@@ -28,9 +29,14 @@ class Test_astartes(unittest.TestCase):
                 [1, 1, 0, 0, 0],
                 [1, 1, 1, 0, 0],
                 [1, 1, 1, 1, 0],
+                [1, 0, 0, 0, 0],
+                [1, 1, 0, 0, 0],
+                [1, 1, 1, 0, 0],
+                [1, 1, 1, 1, 0],
+                [1, 1, 1, 1, 1],
             ]
         )
-        self.y = np.array([1, 2, 3, 4, 5])
+        self.y = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         self.labels = np.array(
             [
                 "one",
@@ -38,8 +44,22 @@ class Test_astartes(unittest.TestCase):
                 "three",
                 "four",
                 "five",
+                "six",
+                "seven",
+                "eight",
+                "nine",
+                "ten",
             ]
         )
+
+    def test_inconsitent_input_lengths(self):
+        """Different length X, y, and labels should raise an exception at start."""
+        with self.assertRaises(InvalidConfigurationError):
+            train_val_test_split(
+                np.array([1, 2]),
+                np.array([1]),
+                np.array([1, 2, 3]),
+            )
 
     def test_train_val_test_split(self):
         """Split data into training, validation, and test sets."""
@@ -80,63 +100,82 @@ class Test_astartes(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array([[0, 1, 0], [1, 1, 1]]),
+                np.array(
+                    [
+                        [1, 1, 0, 0, 0],
+                        [1, 1, 1, 1, 1],
+                        [1, 1, 1, 1, 0],
+                        [1, 1, 1, 0, 0],
+                        [1, 1, 0, 0, 0],
+                        [1, 1, 1, 1, 0],
+                    ]
+                ),
                 "Train X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_val,
-                np.array([[0, 0, 0]]),
+                np.array(
+                    [
+                        [0, 0, 0, 0, 0],
+                        [1, 1, 1, 0, 0],
+                    ]
+                ),
                 "Validation X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[0, 0, 0]]),
+                np.array(
+                    [
+                        [1, 0, 0, 0, 0],
+                        [1, 0, 0, 0, 0],
+                    ]
+                ),
                 "Test X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([2, 3]),
+                np.array([3, 10, 5, 4, 7, 9]),
                 "Train y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_val,
-                np.array([1]),
+                np.array([1, 8]),
                 "Validation y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([1]),
+                np.array([2, 6]),
                 "Test y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["two", "three"]),
+                np.array(["three", "ten", "five", "four", "seven", "nine"]),
                 "Train labels incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_val,
-                np.array(["one"]),
+                np.array(["one", "eight"]),
                 "Validation labels incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["one"]),
+                np.array(["two", "six"]),
                 "Test labels incorrect.",
             )
         )
@@ -144,6 +183,13 @@ class Test_astartes(unittest.TestCase):
     def test_insufficient_dataset(self):
         """If the user requests a split that would result in rounding down the size of the
         test set to zero, a helpful exception should be raised."""
+        with self.assertRaises(InvalidConfigurationError):
+            train_val_test_split(
+                self.X,
+                train_size=None,  # this will result in an empty train set due to rounding
+                val_size=0.4,
+                test_size=0.6,
+            )
 
     def test_split_validation(self):
         """Tests of the input split validation."""
@@ -159,16 +205,24 @@ class Test_astartes(unittest.TestCase):
             train_val_test_split(
                 self.X,
                 train_size=0.2,
-                val_size=0.4,
-                test_size=0.4,
+                val_size=0.2,
+                test_size=0.6,
             )
         with self.subTest("all specified imperfectly"):
             with self.assertWarns(NormalizationWarning):
                 train_val_test_split(
                     self.X,
-                    train_size=0.8,
-                    val_size=0.4,
-                    test_size=2,
+                    train_size=20,
+                    val_size=0.2,
+                    test_size=60,
+                )
+        with self.subTest("invalid val_size"):
+            with self.assertRaises(InvalidConfigurationError):
+                train_val_test_split(
+                    self.X,
+                    train_size=20,
+                    val_size=20,
+                    test_size=60,
                 )
         with self.subTest("no val_size w/ test and train"):
             with self.assertWarns(NormalizationWarning):
@@ -176,7 +230,7 @@ class Test_astartes(unittest.TestCase):
                     self.X,
                     train_size=0.8,
                     val_size=None,
-                    test_size=2,
+                    test_size=0.3,
                 )
         with self.subTest("invalid val_size"):
             with self.assertRaises(RuntimeError):
@@ -187,13 +241,12 @@ class Test_astartes(unittest.TestCase):
                     test_size=None,
                 )
         with self.subTest("val_size w/ valid test_size"):
-            with self.assertWarns(ImperfectSplittingWarning):
-                train_val_test_split(
-                    self.X,
-                    train_size=None,
-                    val_size=0.4,
-                    test_size=0.6,
-                )
+            train_val_test_split(
+                self.X,
+                train_size=None,
+                val_size=0.4,
+                test_size=0.2,
+            )
         with self.subTest("val_size w/ invalid test_size"):
             with self.assertRaises(RuntimeError):
                 train_val_test_split(
@@ -219,13 +272,12 @@ class Test_astartes(unittest.TestCase):
                     test_size=None,
                 )
         with self.subTest("no val_size w/ valid test_size"):
-            with self.assertWarns(ImperfectSplittingWarning):
-                train_val_test_split(
-                    self.X,
-                    train_size=None,
-                    val_size=None,
-                    test_size=0.5,
-                )
+            train_val_test_split(
+                self.X,
+                train_size=None,
+                val_size=None,
+                test_size=0.5,
+            )
         with self.subTest("no val_size w/ invalid test_size"):
             with self.assertRaises(RuntimeError):
                 train_val_test_split(
@@ -237,7 +289,7 @@ class Test_astartes(unittest.TestCase):
         with self.subTest("no val_size w/ valid train_size"):
             train_val_test_split(
                 self.X,
-                train_size=0.8,
+                train_size=0.6,
                 val_size=None,
                 test_size=None,
             )
@@ -282,14 +334,14 @@ class Test_astartes(unittest.TestCase):
                 np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
                 np.array([10, 11, 12]),
                 labels=np.array(["apple", "banana", "apple"]),
-                test_size=0.3,
-                train_size=0.7,
+                test_size=0.5,
+                train_size=0.5,
                 sampler="random",
                 hopts={
                     "random_state": 42,
                 },
             )
-            for elt, ans in zip(X_train.flatten(), [4, 5, 6, 7, 8, 9]):
+            for elt, ans in zip(X_train.flatten(), [7, 8, 9, 1, 2, 3]):
                 self.assertEqual(elt, ans)
 
     def test_return_indices(self):
@@ -299,15 +351,15 @@ class Test_astartes(unittest.TestCase):
                 np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
                 np.array([10, 11, 12]),
                 labels=np.array(["apple", "banana", "apple"]),
-                test_size=0.3,
-                train_size=0.7,
+                test_size=0.5,
+                train_size=0.5,
                 sampler="random",
                 hopts={
                     "random_state": 42,
                 },
                 return_indices=True,
             )
-            for elt, ans in zip(indices_train.flatten(), [1, 2]):
+            for elt, ans in zip(indices_train.flatten(), [2, 0]):
                 self.assertEqual(elt, ans)
 
 

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -10,7 +10,7 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
-from astartes.utils.exceptions import NotImplementedError, InvalidConfigurationError
+from astartes.utils.exceptions import InvalidConfigurationError, NotImplementedError
 from astartes.utils.warnings import ImperfectSplittingWarning, NormalizationWarning
 
 

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -2,7 +2,6 @@ import os
 import sys
 import unittest
 import warnings
-import functools
 
 import numpy as np
 

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -51,7 +51,7 @@ class Test_astartes(unittest.TestCase):
             ]
         )
 
-    def test_inconsitent_input_lengths(self):
+    def test_inconsistent_input_lengths(self):
         """Different length X, y, and labels should raise an exception at start."""
         with self.assertRaises(InvalidConfigurationError):
             train_val_test_split(
@@ -179,7 +179,7 @@ class Test_astartes(unittest.TestCase):
             )
         )
 
-    def test_insufficient_dataset(self):
+    def test_insufficient_dataset_train(self):
         """If the user requests a split that would result in rounding down the size of the
         test set to zero, a helpful exception should be raised."""
         with self.assertRaises(InvalidConfigurationError):
@@ -188,6 +188,28 @@ class Test_astartes(unittest.TestCase):
                 train_size=None,  # this will result in an empty train set due to rounding
                 val_size=0.4,
                 test_size=0.6,
+            )
+
+    def test_insufficient_dataset_val(self):
+        """If the user requests a split that would result in rounding down the size of the
+        test set to zero, a helpful exception should be raised."""
+        with self.assertRaises(InvalidConfigurationError):
+            train_val_test_split(
+                self.X,
+                train_size=0.45,
+                val_size=0.05,  # this will result in an empty val set due to rounding
+                test_size=0.5,
+            )
+
+    def test_insufficient_dataset_test(self):
+        """If the user requests a split that would result in rounding down the size of the
+        test set to zero, a helpful exception should be raised."""
+        with self.assertRaises(InvalidConfigurationError):
+            train_val_test_split(
+                self.X,
+                train_size=0.01,  # this will result in an empty train set due to rounding
+                val_size=0.98,
+                test_size=0.01,  # empty test due to rounding
             )
 
     def test_split_validation(self):

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -1,10 +1,12 @@
 import os
 import sys
 import unittest
+import warnings
 
 import numpy as np
 
 from astartes import train_test_split
+from astartes import train_val_test_split
 from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
@@ -20,7 +22,125 @@ class Test_astartes(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        return
+        self.X = np.array(
+            [
+                [0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0],
+                [1, 1, 0, 0, 0],
+                [1, 1, 1, 0, 0],
+                [1, 1, 1, 1, 0],
+            ]
+        )
+        self.y = np.array([1, 2, 3, 4, 5])
+        self.labels = np.array(
+            [
+                "one",
+                "two",
+                "three",
+                "four",
+                "five",
+            ]
+        )
+
+    def test_train_val_test_split(self):
+        """Split data into training, validation, and test sets."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always")
+            (
+                X_train,
+                X_val,
+                X_test,
+                y_train,
+                y_val,
+                y_test,
+                labels_train,
+                labels_val,
+                labels_test,
+            ) = train_val_test_split(
+                self.X,
+                self.y,
+                labels=self.labels,
+                test_size=0.2,
+                val_size = 0.2,
+                train_size=0.6,
+                sampler="random",
+                hopts={
+                    "random_state": 42,
+                },
+            )
+            self.assertFalse(
+                len(w),
+                "\nNo warnings should have been raised when requesting a mathematically possible split."
+                "\nReceived {:d} warnings instead: \n -> {:s}".format(
+                    len(w),
+                    "\n -> ".join(
+                        [str(i.category.__name__) + ": " + str(i.message) for i in w]
+                    ),
+                ),
+            )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_train,
+                np.array([[0, 1, 0], [1, 1, 1]]),
+                "Train X incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_val,
+                np.array([[0, 0, 0]]),
+                "Validation X incorrect.",
+            )            
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_test,
+                np.array([[0, 0, 0]]),
+                "Test X incorrect.",
+            )            
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_train,
+                np.array([2, 3]),
+                "Train y incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_val,
+                np.array([1]),
+                "Validation y incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_test,
+                np.array([1]),
+                "Test y incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_train,
+                np.array(["two", "three"]),
+                "Train labels incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_val,
+                np.array(["one"]),
+                "Validation labels incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_test,
+                np.array(["one"]),
+                "Test labels incorrect.",
+            )
+        )
 
     def test_insufficient_dataset(self):
         """If the user requests a split that would result in rounding down the size of the

--- a/test/test_molecules.py
+++ b/test/test_molecules.py
@@ -10,6 +10,7 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
+from astartes.utils.warnings import ImperfectSplittingWarning
 
 
 class Test_molecules(unittest.TestCase):
@@ -37,14 +38,15 @@ class Test_molecules(unittest.TestCase):
 
     def test_molecules(self):
         """ """
-        for sampler in IMPLEMENTED_INTERPOLATION_SAMPLERS:
-            tts = train_test_split_molecules(
-                self.X,
-                self.y,
-                0.2,
-                sampler=sampler,
-                fprints_hopts={"n_bits": 100},
-            )
+        with self.assertWarns(ImperfectSplittingWarning):
+            for sampler in IMPLEMENTED_INTERPOLATION_SAMPLERS:
+                tts = train_test_split_molecules(
+                    self.X,
+                    self.y,
+                    0.2,
+                    sampler=sampler,
+                    fprints_hopts={"n_bits": 100},
+                )
 
     def test_fingerprints(self):
         for fprint in [
@@ -62,54 +64,67 @@ class Test_molecules(unittest.TestCase):
                 )
 
     def test_fprint_hopts(self):
-        tts = train_test_split_molecules(
-            self.X,
-            self.y,
-            0.2,
-            sampler="random",
-            fingerprint="topological_fingerprint",
-            fprints_hopts={
-                "minPath": 2,
-                "maxPath": 5,
-                "fpSize": 200,
-                "bitsPerHash": 4,
-                "useHs": 1,
-                "tgtDensity": 0.4,
-                "minSize": 64,
-            },
-        )
+        with self.assertWarns(ImperfectSplittingWarning):
+            tts = train_test_split_molecules(
+                self.X,
+                self.y,
+                0.2,
+                sampler="random",
+                fingerprint="topological_fingerprint",
+                fprints_hopts={
+                    "minPath": 2,
+                    "maxPath": 5,
+                    "fpSize": 200,
+                    "bitsPerHash": 4,
+                    "useHs": 1,
+                    "tgtDensity": 0.4,
+                    "minSize": 64,
+                },
+            )
 
     def test_sampler_hopts(self):
-        tts = train_test_split_molecules(
-            self.X,
-            self.y,
-            0.2,
-            sampler="random",
-            hopts={
-                "random_state": 42,
-            },
-        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always")
+            tts = train_test_split_molecules(
+                self.X,
+                self.y,
+                sampler="random",
+                hopts={
+                    "random_state": 42,
+                },
+            )
+            self.assertFalse(
+                len(w),
+                "\nNo warnings should have been raised when requesting a mathematically possible split."
+                "\nReceived {:d} warnings instead: \n -> {:s}".format(
+                    len(w),
+                    "\n -> ".join(
+                        [str(i.category.__name__) + ": " + str(i.message) for i in w]
+                    ),
+                ),
+            )
 
     def test_maximum_call(self):
-        tts = train_test_split_molecules(
-            self.X,
-            self.y,
-            0.2,
-            fingerprint="topological_fingerprint",
-            fprints_hopts={
-                "minPath": 2,
-                "maxPath": 5,
-                "fpSize": 200,
-                "bitsPerHash": 4,
-                "useHs": 1,
-                "tgtDensity": 0.4,
-                "minSize": 64,
-            },
-            sampler="random",
-            hopts={
-                "random_state": 42,
-            },
-        )
+        with self.assertWarns(ImperfectSplittingWarning):
+            tts = train_test_split_molecules(
+                self.X,
+                self.y,
+                0.2,
+                fingerprint="topological_fingerprint",
+                fprints_hopts={
+                    "minPath": 2,
+                    "maxPath": 5,
+                    "fpSize": 200,
+                    "bitsPerHash": 4,
+                    "useHs": 1,
+                    "tgtDensity": 0.4,
+                    "minSize": 64,
+                },
+                sampler="random",
+                hopts={
+                    "random_state": 42,
+                },
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_molecules.py
+++ b/test/test_molecules.py
@@ -5,7 +5,10 @@ import warnings
 
 import numpy as np
 
-from astartes.molecules import train_test_split_molecules
+from astartes.molecules import (
+    train_test_split_molecules,
+    train_val_test_split_molecules,
+)
 from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
@@ -42,10 +45,22 @@ class Test_molecules(unittest.TestCase):
             tts = train_test_split_molecules(
                 self.X,
                 self.y,
-                0.2,
+                train_size=0.2,
                 sampler=sampler,
                 fprints_hopts={"n_bits": 100},
             )
+
+    def test_validation_split_molecules(self):
+        """ """
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for sampler in IMPLEMENTED_EXTRAPOLATION_SAMPLERS:
+                tts = train_val_test_split_molecules(
+                    self.X,
+                    self.y,
+                    sampler=sampler,
+                    fprints_hopts={"n_bits": 100},
+                )
 
     def test_fingerprints(self):
         for fprint in [
@@ -57,7 +72,7 @@ class Test_molecules(unittest.TestCase):
                 tts = train_test_split_molecules(
                     self.X,
                     self.y,
-                    0.2,
+                    test_size=0.2,
                     sampler="random",
                     fingerprint=fprint,
                 )
@@ -66,7 +81,7 @@ class Test_molecules(unittest.TestCase):
         tts = train_test_split_molecules(
             self.X,
             self.y,
-            0.2,
+            train_size=0.2,
             sampler="random",
             fingerprint="topological_fingerprint",
             fprints_hopts={
@@ -106,7 +121,7 @@ class Test_molecules(unittest.TestCase):
         tts = train_test_split_molecules(
             self.X,
             self.y,
-            0.2,
+            train_size=0.2,
             fingerprint="topological_fingerprint",
             fprints_hopts={
                 "minPath": 2,

--- a/test/test_molecules.py
+++ b/test/test_molecules.py
@@ -38,15 +38,14 @@ class Test_molecules(unittest.TestCase):
 
     def test_molecules(self):
         """ """
-        with self.assertWarns(ImperfectSplittingWarning):
-            for sampler in IMPLEMENTED_INTERPOLATION_SAMPLERS:
-                tts = train_test_split_molecules(
-                    self.X,
-                    self.y,
-                    0.2,
-                    sampler=sampler,
-                    fprints_hopts={"n_bits": 100},
-                )
+        for sampler in IMPLEMENTED_INTERPOLATION_SAMPLERS:
+            tts = train_test_split_molecules(
+                self.X,
+                self.y,
+                0.2,
+                sampler=sampler,
+                fprints_hopts={"n_bits": 100},
+            )
 
     def test_fingerprints(self):
         for fprint in [
@@ -64,23 +63,22 @@ class Test_molecules(unittest.TestCase):
                 )
 
     def test_fprint_hopts(self):
-        with self.assertWarns(ImperfectSplittingWarning):
-            tts = train_test_split_molecules(
-                self.X,
-                self.y,
-                0.2,
-                sampler="random",
-                fingerprint="topological_fingerprint",
-                fprints_hopts={
-                    "minPath": 2,
-                    "maxPath": 5,
-                    "fpSize": 200,
-                    "bitsPerHash": 4,
-                    "useHs": 1,
-                    "tgtDensity": 0.4,
-                    "minSize": 64,
-                },
-            )
+        tts = train_test_split_molecules(
+            self.X,
+            self.y,
+            0.2,
+            sampler="random",
+            fingerprint="topological_fingerprint",
+            fprints_hopts={
+                "minPath": 2,
+                "maxPath": 5,
+                "fpSize": 200,
+                "bitsPerHash": 4,
+                "useHs": 1,
+                "tgtDensity": 0.4,
+                "minSize": 64,
+            },
+        )
 
     def test_sampler_hopts(self):
         with warnings.catch_warnings(record=True) as w:
@@ -105,26 +103,25 @@ class Test_molecules(unittest.TestCase):
             )
 
     def test_maximum_call(self):
-        with self.assertWarns(ImperfectSplittingWarning):
-            tts = train_test_split_molecules(
-                self.X,
-                self.y,
-                0.2,
-                fingerprint="topological_fingerprint",
-                fprints_hopts={
-                    "minPath": 2,
-                    "maxPath": 5,
-                    "fpSize": 200,
-                    "bitsPerHash": 4,
-                    "useHs": 1,
-                    "tgtDensity": 0.4,
-                    "minSize": 64,
-                },
-                sampler="random",
-                hopts={
-                    "random_state": 42,
-                },
-            )
+        tts = train_test_split_molecules(
+            self.X,
+            self.y,
+            0.2,
+            fingerprint="topological_fingerprint",
+            fprints_hopts={
+                "minPath": 2,
+                "maxPath": 5,
+                "fpSize": 200,
+                "bitsPerHash": 4,
+                "useHs": 1,
+                "tgtDensity": 0.4,
+                "minSize": 64,
+            },
+            sampler="random",
+            hopts={
+                "random_state": 42,
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The former should be the "base case" and the latter should just call it with `val_size=0.0` -- reduces development burden and will hopefully help motivate users to try out validation.
 - [x] implement `train_test_val_split`
 - [x] add `train_test_val_split_molecules`

Resolves #17 