### PR TITLE
Avoid redefining Python's native `NotImplementedError`

### DIFF
--- a/astartes/utils/exceptions.py
+++ b/astartes/utils/exceptions.py
@@ -17,7 +17,7 @@ class InvalidConfigurationError(RuntimeError):
         super().__init__(message)
 
 
-class NotImplementedError(RuntimeError):
+class SamplerNotImplementedError(RuntimeError):
     """Used when attempting to call a non-existent sampler."""
 
     def __init__(self, message=None):

--- a/astartes/utils/sampler_factory.py
+++ b/astartes/utils/sampler_factory.py
@@ -8,7 +8,7 @@ from astartes.samplers import (
     Random,
     SphereExclusion,
 )
-from astartes.utils.exceptions import NotImplementedError
+from astartes.utils.exceptions import SamplerNotImplementedError
 
 
 class SamplerFactory:
@@ -30,7 +30,7 @@ class SamplerFactory:
             hopts (dict): Hyperparameters for the sampler.
 
         Raises:
-            NotImplementedError: Raised when an non-existent or not yet implemented sampler is requested.
+            SamplerNotImplementedError: Raised when an non-existent or not yet implemented sampler is requested.
 
         Returns:
             astartes.sampler: The fit sampler instance.
@@ -56,7 +56,7 @@ class SamplerFactory:
                 if possiblity
                 else " Try help(train_test_split)."
             )
-            raise NotImplementedError(
+            raise SamplerNotImplementedError(
                 "Sampler {:s} has not been implemented.".format(self.sampler) + addendum
             )
         return sampler_class(X, y, labels, hopts)

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -10,7 +10,7 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
-from astartes.utils.exceptions import InvalidConfigurationError, NotImplementedError
+from astartes.utils.exceptions import InvalidConfigurationError, SamplerNotImplementedError
 from astartes.utils.warnings import ImperfectSplittingWarning, NormalizationWarning
 
 
@@ -326,7 +326,7 @@ class Test_astartes(unittest.TestCase):
 
     def test_close_mispelling_sampler(self):
         """Astartes should be helpful in the event of a typo."""
-        with self.assertRaises(NotImplementedError) as e:
+        with self.assertRaises(SamplerNotImplementedError) as e:
             train_test_split([], sampler="radnom")
             self.assertEqual(
                 e.exception,
@@ -335,7 +335,7 @@ class Test_astartes(unittest.TestCase):
 
     def test_not_implemented_sampler(self):
         """Astartes should suggest checking the docstring."""
-        with self.assertRaises(NotImplementedError) as e:
+        with self.assertRaises(SamplerNotImplementedError) as e:
             train_test_split([], sampler="MIT is overrated")
             self.assertEqual(
                 e.exception,

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -10,7 +10,10 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
-from astartes.utils.exceptions import InvalidConfigurationError, SamplerNotImplementedError
+from astartes.utils.exceptions import (
+    InvalidConfigurationError,
+    SamplerNotImplementedError,
+)
 from astartes.utils.warnings import ImperfectSplittingWarning, NormalizationWarning
 
 


### PR DESCRIPTION
Minor PR that proposes renaming one of the exceptions to avoid redefining the native exception in Python. I'm fine if you prefer the original implementation and want to disregard this PR