### PR TITLE
Add SPXY Sampler, Fix Bug in Interpolative Sampler Set Filling

### DIFF
--- a/astartes/main.py
+++ b/astartes/main.py
@@ -171,8 +171,8 @@ def _interpolative_sampling(
     """Helper function to perform interpolative sampling.
 
     Attempts to fill train, val, and test within rounding limits. Prioiritizes underfilling
-    test and then val and then the balance goes into train (which is why the floats are given
-    in that order).
+    train and then val and then the balance goes into test (this is the opposite to extrapolative
+    because these samplers move outisde-in).
 
     Args:
         sampler_instance (sampler): The fit sampler instance.
@@ -184,14 +184,13 @@ def _interpolative_sampling(
     Returns:
         calls: _return_helper
     """
-    # build test first
-    n_test_samples = floor(len(sampler_instance.X) * test_size)
+    n_train_samples = floor(len(sampler_instance.X) * train_size)
     n_val_samples = floor(len(sampler_instance.X) * val_size)
-    n_train_samples = len(sampler_instance.X) - (n_test_samples + n_val_samples)
+    n_test_samples = len(sampler_instance.X) - (n_train_samples + n_val_samples)
 
-    test_idxs = sampler_instance.get_sample_idxs(n_test_samples)
-    val_idxs = sampler_instance.get_sample_idxs(n_val_samples)
     train_idxs = sampler_instance.get_sample_idxs(n_train_samples)
+    val_idxs = sampler_instance.get_sample_idxs(n_val_samples)
+    test_idxs = sampler_instance.get_sample_idxs(n_test_samples)
 
     _check_actual_split(
         train_idxs, val_idxs, test_idxs, train_size, val_size, test_size

--- a/astartes/molecules.py
+++ b/astartes/molecules.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List
 
 import numpy as np
@@ -5,7 +6,15 @@ import numpy as np
 from astartes.utils.exceptions import MoleculesNotInstalledError
 
 try:
-    from aimsim.chemical_datastructures import Molecule
+    """
+    aimsim depends on sklearn_extra, which uses a version checking technique that is due to
+    be deprecated in a version of Python after 3.11, so it is throwing a deprecation warning
+    We ignore this warning since we can't do anything about it (sklearn_extra seems to be
+    abandonware) and in the future it will become an error that we can deal with.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        from aimsim.chemical_datastructures import Molecule
 except ImportError:  # pragma: no cover
     raise MoleculesNotInstalledError(
         """To use molecule featurizer, install astartes with pip install astartes[molecules]."""

--- a/astartes/samplers/__init__.py
+++ b/astartes/samplers/__init__.py
@@ -3,7 +3,7 @@ from .abstract_sampler import AbstractSampler
 
 # implementations
 from .extrapolation import DBSCAN, KMeans, OptiSim, Scaffold, SphereExclusion
-from .interpolation import MTSD, DOptimal, Duplex, KennardStone, Random
+from .interpolation import MTSD, DOptimal, Duplex, KennardStone, Random, SPXY
 
 IMPLEMENTED_INTERPOLATION_SAMPLERS = (
     "random",
@@ -12,6 +12,7 @@ IMPLEMENTED_INTERPOLATION_SAMPLERS = (
     "kennard_stone",
     # "mtsd",
     "sphere_exclusion",
+    "spxy",
 )
 
 IMPLEMENTED_EXTRAPOLATION_SAMPLERS = (

--- a/astartes/samplers/__init__.py
+++ b/astartes/samplers/__init__.py
@@ -11,7 +11,6 @@ IMPLEMENTED_INTERPOLATION_SAMPLERS = (
     # "duplex",
     "kennard_stone",
     # "mtsd",
-    "sphere_exclusion",
     "spxy",
 )
 
@@ -20,6 +19,7 @@ IMPLEMENTED_EXTRAPOLATION_SAMPLERS = (
     # "scaffold",
     "kmeans",
     "optisim",
+    "sphere_exclusion",
 )
 
 ALL_SAMPLERS = IMPLEMENTED_EXTRAPOLATION_SAMPLERS + IMPLEMENTED_INTERPOLATION_SAMPLERS

--- a/astartes/samplers/__init__.py
+++ b/astartes/samplers/__init__.py
@@ -3,7 +3,7 @@ from .abstract_sampler import AbstractSampler
 
 # implementations
 from .extrapolation import DBSCAN, KMeans, OptiSim, Scaffold, SphereExclusion
-from .interpolation import MTSD, DOptimal, Duplex, KennardStone, Random, SPXY
+from .interpolation import MTSD, SPXY, DOptimal, Duplex, KennardStone, Random
 
 IMPLEMENTED_INTERPOLATION_SAMPLERS = (
     "random",

--- a/astartes/samplers/interpolation/__init__.py
+++ b/astartes/samplers/interpolation/__init__.py
@@ -3,3 +3,4 @@ from .duplex import Duplex
 from .kennardstone import KennardStone
 from .mtsd import MTSD
 from .random_split import Random
+from .spxy import SPXY

--- a/astartes/samplers/interpolation/spxy.py
+++ b/astartes/samplers/interpolation/spxy.py
@@ -1,0 +1,52 @@
+"""
+Implements the Sample set Partitioning based on join X-Y distances
+algorithm as originally described by Saldanha and coworkers in
+"A method for calibration and validation subset partitioning"
+doi:10.1016/j.talanta.2005.03.025
+
+This implementation has been validated against their original source
+code implementation, which can be found in the paper linked above.
+The corresponding unit tests reflect the expected output from
+the original implemenation
+"""
+import numpy as np
+from scipy.spatial.distance import pdist, squareform
+
+from astartes.samplers import AbstractSampler
+from astartes.utils.exceptions import InvalidConfigurationError
+
+
+class SPXY(AbstractSampler):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        if self.y is None:
+            raise InvalidConfigurationError(
+                "SPXY sampler requires both X and y arrays. Provide y or switch to kennard_stone."
+            )
+
+    def _sample(self):
+        """
+        Implements the SPXY algorithm as described by Saldahna et al.
+        """
+        distance_metric = self.get_config("metric", "euclidean")
+
+        y_2d = self.y[:, np.newaxis]
+
+        y_pdist = pdist(y_2d, metric=distance_metric)
+        y_pdist = np.divide(y_pdist, np.amax(y_pdist))
+
+        X_dist = pdist(self.X, metric=distance_metric)
+        X_dist = np.divide(X_dist, np.amax(X_dist))
+
+        # sum the distances as per eq. 3 of Saldahna, set diagonal to nan
+        spxy_distance = squareform(y_pdist + X_dist)
+        np.fill_diagonal(spxy_distance, np.nan)
+
+        print(spxy_distance, np.argmin(spxy_distance, keepdims=True))
+
+        self._samples_idxs = np.array([], dtype=int)
+
+    def _pdist_lookup(self, i, j):
+        """Convert matrix i,j to flattened index"""
+        return len(self.X) * i + j - ((i + 2) * (i + 1)) // 2

--- a/astartes/samplers/interpolation/spxy.py
+++ b/astartes/samplers/interpolation/spxy.py
@@ -7,7 +7,9 @@ doi:10.1016/j.talanta.2005.03.025
 This implementation has been validated against their original source
 code implementation, which can be found in the paper linked above.
 The corresponding unit tests reflect the expected output from
-the original implemenation
+the original implemenation. The breaking of ties is different
+compared to the original, but this is ultimately a minor and
+likely inconsequential difference.
 """
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
@@ -29,6 +31,8 @@ class SPXY(AbstractSampler):
         """
         Implements the SPXY algorithm as described by Saldahna et al.
         """
+        n_samples = len(self.X)
+
         distance_metric = self.get_config("metric", "euclidean")
 
         y_2d = self.y[:, np.newaxis]
@@ -41,12 +45,31 @@ class SPXY(AbstractSampler):
 
         # sum the distances as per eq. 3 of Saldahna, set diagonal to nan
         spxy_distance = squareform(y_pdist + X_dist)
-        np.fill_diagonal(spxy_distance, np.nan)
+        np.fill_diagonal(spxy_distance, -np.inf)
 
-        print(spxy_distance, np.argmin(spxy_distance, keepdims=True))
+        # get the row/col of maximum (greatest distance)
+        max_idx = np.nanargmax(spxy_distance)
+        max_coords = np.unravel_index(max_idx, spxy_distance.shape)
 
-        self._samples_idxs = np.array([], dtype=int)
+        # -np.inf these points to trick numpy later on
+        spxy_distance[max_coords[0], :] = -np.inf
+        spxy_distance[max_coords[1], :] = -np.inf
 
-    def _pdist_lookup(self, i, j):
-        """Convert matrix i,j to flattened index"""
-        return len(self.X) * i + j - ((i + 2) * (i + 1)) // 2
+        # list of indices which have been selected, for use in the below loop
+        alread_selected = list()
+        alread_selected.append(max_coords[0])
+        alread_selected.append(max_coords[1])
+
+        # iterate through the rest
+        for _ in range(n_samples - 2):
+            # find the next sample with the largest minimum distance to any sample already selected
+            # get out the columns for the data already selected
+            select_spxy_distance = spxy_distance[:, alread_selected]
+            # find which member of the selected data each of the unselected data is closest to
+            min_distances_vals = np.nanmin(select_spxy_distance, axis=1)
+            # pick the largest of those values
+            max_min_idx = np.nanargmax(min_distances_vals)
+            spxy_distance[max_min_idx, :] = -np.inf
+            alread_selected.append(max_min_idx)
+
+        self._samples_idxs = np.array(alread_selected, dtype=int)

--- a/astartes/samplers/interpolation/spxy.py
+++ b/astartes/samplers/interpolation/spxy.py
@@ -20,12 +20,11 @@ from astartes.utils.exceptions import InvalidConfigurationError
 
 class SPXY(AbstractSampler):
     def __init__(self, *args):
-        super().__init__(*args)
-
-        if self.y is None:
+        if args[1] is None:
             raise InvalidConfigurationError(
                 "SPXY sampler requires both X and y arrays. Provide y or switch to kennard_stone."
             )
+        super().__init__(*args)
 
     def _sample(self):
         """

--- a/astartes/utils/sampler_factory.py
+++ b/astartes/utils/sampler_factory.py
@@ -8,6 +8,7 @@ from astartes.samplers import (
     OptiSim,
     Random,
     SphereExclusion,
+    SPXY,
 )
 from astartes.utils.exceptions import SamplerNotImplementedError
 
@@ -48,6 +49,8 @@ class SamplerFactory:
             sampler_class = SphereExclusion
         elif self.sampler == "optisim":
             sampler_class = OptiSim
+        elif self.sampler == "spxy":
+            sampler_class = SPXY
         else:
             possiblity = get_close_matches(
                 self.sampler,

--- a/astartes/utils/sampler_factory.py
+++ b/astartes/utils/sampler_factory.py
@@ -3,12 +3,12 @@ from difflib import get_close_matches
 from astartes.samplers import (
     ALL_SAMPLERS,
     DBSCAN,
+    SPXY,
     KennardStone,
     KMeans,
     OptiSim,
     Random,
     SphereExclusion,
-    SPXY,
 )
 from astartes.utils.exceptions import SamplerNotImplementedError
 

--- a/test/samplers/test_kennard_stone.py
+++ b/test/samplers/test_kennard_stone.py
@@ -72,50 +72,50 @@ class Test_kennard_stone(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.7,
-                train_size=0.3,
+                test_size=0.3,
+                train_size=0.7,
                 sampler="kennard_stone",
             )
         # test that the known arrays equal the result from above
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array([[0, 1, 0]]),
+                np.array([[0, 0, 0], [1, 1, 1]]),
                 "Train X incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[0, 0, 0], [1, 1, 1]]),
+                np.array([[0, 1, 0]]),
                 "Test X incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([2]),
+                np.array([1, 3]),
                 "Train y incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([1, 3]),
+                np.array([2]),
                 "Test y incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["two"]),
+                np.array(["one", "three"]),
                 "Train labels incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["one", "three"]),
+                np.array(["two"]),
                 "Test labels incorrect.",
             ),
         )
@@ -135,8 +135,8 @@ class Test_kennard_stone(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.67,
-                train_size=0.33,
+                test_size=0.33,
+                train_size=0.67,
                 sampler="kennard_stone",
             )
             self.assertFalse(

--- a/test/samplers/test_random.py
+++ b/test/samplers/test_random.py
@@ -64,8 +64,8 @@ class Test_random(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.75,
-                train_size=0.25,
+                test_size=0.5,
+                train_size=0.5,
                 sampler="random",
                 hopts={
                     "random_state": 42,
@@ -75,42 +75,42 @@ class Test_random(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array([[0, 0, 0]]),
+                np.array([[0, 1, 0]]),
                 "Train X incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[0, 1, 0], [1, 1, 1]]),
+                np.array([[1, 1, 1], [0, 0, 0]]),
                 "Test X incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([1]),
+                np.array([2]),
                 "Train y incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([2, 3]),
+                np.array([3, 1]),
                 "Test y incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["one"]),
+                np.array(["two"]),
                 "Train labels incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["two", "three"]),
+                np.array(["three", "one"]),
                 "Test labels incorrect.",
             ),
         )
@@ -130,8 +130,8 @@ class Test_random(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.67,
-                train_size=0.33,
+                test_size=0.33,
+                train_size=0.67,
                 sampler="random",
                 hopts={
                     "random_state": 42,

--- a/test/samplers/test_spxy.py
+++ b/test/samplers/test_spxy.py
@@ -1,0 +1,149 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+
+from astartes import train_test_split
+from astartes.samplers import SPXY
+from astartes.utils.warnings import ImperfectSplittingWarning
+
+
+class Test_SPXY(unittest.TestCase):
+    """
+    Test the various functionalities of SPXY.
+    """
+
+    @classmethod
+    def setUpClass(self):
+        """Convenience attributes for later tests."""
+        self.X = np.array(
+            [
+                [1, 0, 0, 0, 0, 0, 0],
+                [1, 1, 0, 0, 0, 0, 0],
+                [1, 1, 1, 0, 0, 0, 0],
+                [1, 1, 1, 1, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 0],
+                [1, 1, 1, 1, 1, 1, 1],
+            ]
+        )
+        self.y = np.array([1, 2, 3, 4, 5, 6])
+        self.labels = np.array(
+            [
+                "one",
+                "two",
+                "three",
+                "four",
+                "five",
+                "six",
+            ]
+        )
+
+    def test_spxy_sampling(self):
+        """Use spxy in the train_test_split and verify results."""
+        with self.assertWarns(ImperfectSplittingWarning):
+            (
+                X_train,
+                X_test,
+                y_train,
+                y_test,
+                labels_train,
+                labels_test,
+                clusters_train,
+                clusters_test,
+            ) = train_test_split(
+                self.X,
+                self.y,
+                labels=self.labels,
+                test_size=0.7,
+                train_size=0.3,
+                sampler="spxy",
+                hopts={
+                    "metric": "euclidean",
+                },
+            )
+        # test that the known arrays equal the result from above
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_train,
+                np.array(
+                    [
+                        [1, 0, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 1, 1, 1, 1],
+                        [1, 1, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 0, 0, 0, 0],
+                    ]
+                ),
+                "Train X incorrect.",
+            ),
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_test,
+                np.array(
+                    [
+                        [1, 1, 1, 1, 0, 0, 0],
+                        [1, 1, 1, 1, 1, 1, 0],
+                    ]
+                ),
+                "Test X incorrect.",
+            ),
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_train,
+                np.array([1, 6, 3, 2]),
+                "Train y incorrect.",
+            ),
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_test,
+                np.array([4, 5]),
+                "Test y incorrect.",
+            ),
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_train,
+                np.array(["one", "six", "three", "two"]),
+                "Train labels incorrect.",
+            ),
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_test,
+                np.array(["four", "five"]),
+                "Test labels incorrect.",
+            ),
+        )
+
+    def test_spxy(self):
+        """Directly instantiate and test SPXY"""
+        spxy_instance = SPXY(
+            self.X,
+            self.y,
+            self.labels,
+            {},
+        )
+        self.assertIsInstance(
+            spxy_instance,
+            SPXY,
+            "Failed instantiation.",
+        )
+        self.assertFalse(
+            len(spxy_instance.get_clusters()),
+            "Clusters should not have been set.",
+        )
+        self.assertFalse(
+            len(spxy_instance.get_sorted_cluster_counter()),
+            "Sorted cluster Counter should not be found.",
+        )
+        self.assertTrue(
+            len(spxy_instance._samples_idxs),
+            "Sample indices not set.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/samplers/test_spxy.py
+++ b/test/samplers/test_spxy.py
@@ -19,15 +19,15 @@ class Test_SPXY(unittest.TestCase):
         """Convenience attributes for later tests."""
         self.X = np.array(
             [
-                [1, 0, 0, 0, 0, 0, 0],
-                [1, 1, 0, 0, 0, 0, 0],
-                [1, 1, 1, 0, 0, 0, 0],
-                [1, 1, 1, 1, 0, 0, 0],
-                [1, 1, 1, 1, 1, 1, 0],
-                [1, 1, 1, 1, 1, 1, 1],
+                [4, 1, 9, 5, 5, 7],
+                [10, 9, 3, 3, 8, 2],
+                [8, 7, 2, 7, 2, 1],
+                [6, 8, 2, 2, 6, 10],
+                [2, 1, 4, 3, 6, 10],
+                [2, 10, 6, 4, 1, 9],
             ]
         )
-        self.y = np.array([1, 2, 3, 4, 5, 6])
+        self.y = np.array([4, 1, 7, 5, 2, 5])
         self.labels = np.array(
             [
                 "one",
@@ -49,14 +49,12 @@ class Test_SPXY(unittest.TestCase):
                 y_test,
                 labels_train,
                 labels_test,
-                clusters_train,
-                clusters_test,
             ) = train_test_split(
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.7,
-                train_size=0.3,
+                test_size=0.4,
+                train_size=0.6,
                 sampler="spxy",
                 hopts={
                     "metric": "euclidean",
@@ -68,8 +66,8 @@ class Test_SPXY(unittest.TestCase):
                 X_train,
                 np.array(
                     [
-                        [1, 0, 0, 0, 0, 0, 0],
-                        [1, 1, 1, 1, 1, 1, 1],
+                        [8, 7, 2, 7, 2, 1],
+                        [2, 10, 6, 4, 1, 9],
                         [1, 1, 0, 0, 0, 0, 0],
                         [1, 1, 1, 0, 0, 0, 0],
                     ]

--- a/test/samplers/test_spxy.py
+++ b/test/samplers/test_spxy.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from astartes import train_test_split
 from astartes.samplers import SPXY
+from astartes.utils.exceptions import InvalidConfigurationError
 from astartes.utils.warnings import ImperfectSplittingWarning
 
 
@@ -38,6 +39,15 @@ class Test_SPXY(unittest.TestCase):
                 "six",
             ]
         )
+
+    def test_missing_y(self):
+        """SPXY requires a y array and should complain when one is not provided."""
+        with self.assertRaises(InvalidConfigurationError):
+            train_test_split(
+                self.X,
+                y=None,
+                sampler="spxy",
+            )
 
     def test_spxy_sampling(self):
         """Use spxy in the train_test_split and verify results."""

--- a/test/samplers/test_spxy.py
+++ b/test/samplers/test_spxy.py
@@ -53,8 +53,8 @@ class Test_SPXY(unittest.TestCase):
                 self.X,
                 self.y,
                 labels=self.labels,
-                test_size=0.4,
-                train_size=0.6,
+                test_size=0.3,
+                train_size=0.7,
                 sampler="spxy",
                 hopts={
                     "metric": "euclidean",
@@ -67,9 +67,9 @@ class Test_SPXY(unittest.TestCase):
                 np.array(
                     [
                         [8, 7, 2, 7, 2, 1],
+                        [2, 1, 4, 3, 6, 10],
+                        [10, 9, 3, 3, 8, 2],
                         [2, 10, 6, 4, 1, 9],
-                        [1, 1, 0, 0, 0, 0, 0],
-                        [1, 1, 1, 0, 0, 0, 0],
                     ]
                 ),
                 "Train X incorrect.",
@@ -80,8 +80,8 @@ class Test_SPXY(unittest.TestCase):
                 X_test,
                 np.array(
                     [
-                        [1, 1, 1, 1, 0, 0, 0],
-                        [1, 1, 1, 1, 1, 1, 0],
+                        [4, 1, 9, 5, 5, 7],
+                        [6, 8, 2, 2, 6, 10],
                     ]
                 ),
                 "Test X incorrect.",
@@ -90,7 +90,7 @@ class Test_SPXY(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([1, 6, 3, 2]),
+                np.array([7, 2, 1, 5]),
                 "Train y incorrect.",
             ),
         )
@@ -104,14 +104,14 @@ class Test_SPXY(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["one", "six", "three", "two"]),
+                np.array(["three", "five", "two", "six"]),
                 "Train labels incorrect.",
             ),
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["four", "five"]),
+                np.array(["one", "four"]),
                 "Test labels incorrect.",
             ),
         )

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -201,9 +201,10 @@ class Test_astartes(unittest.TestCase):
         with self.assertRaises(InvalidConfigurationError):
             train_val_test_split(
                 self.X,
-                train_size=0.01,  # this will result in an empty train set due to rounding
-                val_size=0.98,
+                train_size=0.49,
+                val_size=0.5,
                 test_size=0.01,  # empty test due to rounding
+                sampler="kmeans",
             )
 
     def test_split_validation(self):

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -100,19 +100,6 @@ class Test_astartes(unittest.TestCase):
                     ),
                 ),
             )
-            print(
-                (
-                    X_train,
-                    X_val,
-                    X_test,
-                    y_train,
-                    y_val,
-                    y_test,
-                    labels_train,
-                    labels_val,
-                    labels_test,
-                )
-            )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
@@ -284,7 +271,7 @@ class Test_astartes(unittest.TestCase):
                     test_size=None,
                 )
         with self.subTest("val_size w/ valid test_size"):
-            with self.assertRaises(ImperfectSplittingWarning):
+            with self.assertWarns(ImperfectSplittingWarning):
                 train_val_test_split(
                     self.X,
                     train_size=None,

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -100,17 +100,30 @@ class Test_astartes(unittest.TestCase):
                     ),
                 ),
             )
+            print(
+                (
+                    X_train,
+                    X_val,
+                    X_test,
+                    y_train,
+                    y_val,
+                    y_test,
+                    labels_train,
+                    labels_val,
+                    labels_test,
+                )
+            )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
                 np.array(
                     [
-                        [1, 1, 0, 0, 0],
-                        [1, 1, 1, 1, 1],
-                        [1, 1, 1, 1, 0],
+                        [1, 0, 0, 0, 0],
+                        [1, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
                         [1, 1, 1, 0, 0],
                         [1, 1, 0, 0, 0],
-                        [1, 1, 1, 1, 0],
+                        [1, 1, 1, 1, 1],
                     ]
                 ),
                 "Train X incorrect.",
@@ -119,66 +132,56 @@ class Test_astartes(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_val,
-                np.array(
-                    [
-                        [0, 0, 0, 0, 0],
-                        [1, 1, 1, 0, 0],
-                    ]
-                ),
+                np.array([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]]),
                 "Validation X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array(
-                    [
-                        [1, 0, 0, 0, 0],
-                        [1, 0, 0, 0, 0],
-                    ]
-                ),
+                np.array([[1, 1, 0, 0, 0], [1, 1, 1, 1, 0]]),
                 "Test X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([3, 10, 5, 4, 7, 9]),
+                np.array([2, 6, 1, 8, 3, 10]),
                 "Train y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_val,
-                np.array([1, 8]),
+                np.array([5, 4]),
                 "Validation y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([2, 6]),
+                np.array([7, 9]),
                 "Test y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["three", "ten", "five", "four", "seven", "nine"]),
+                np.array(["two", "six", "one", "eight", "three", "ten"]),
                 "Train labels incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_val,
-                np.array(["one", "eight"]),
+                np.array(["five", "four"]),
                 "Validation labels incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["two", "six"]),
+                np.array(["seven", "nine"]),
                 "Test labels incorrect.",
             )
         )
@@ -234,13 +237,28 @@ class Test_astartes(unittest.TestCase):
                 test_size=0.6,
             )
         with self.subTest("all specified imperfectly"):
-            with self.assertWarns(NormalizationWarning):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always")
                 train_val_test_split(
                     self.X,
                     train_size=20,
                     val_size=0.2,
                     test_size=60,
                 )
+                self.assertTrue(
+                    len(w) == 2,
+                    "\nTwo warnings should have been raised when requesting a mathematically impossible split."
+                    "\nReceived {:d} warnings instead: \n -> {:s}".format(
+                        len(w),
+                        "\n -> ".join(
+                            [
+                                str(i.category.__name__) + ": " + str(i.message)
+                                for i in w
+                            ]
+                        ),
+                    ),
+                )
+
         with self.subTest("invalid val_size"):
             with self.assertRaises(InvalidConfigurationError):
                 train_val_test_split(
@@ -253,9 +271,9 @@ class Test_astartes(unittest.TestCase):
             with self.assertWarns(NormalizationWarning):
                 train_val_test_split(
                     self.X,
-                    train_size=0.8,
+                    train_size=7,
                     val_size=None,
-                    test_size=0.3,
+                    test_size=3,
                 )
         with self.subTest("invalid val_size"):
             with self.assertRaises(RuntimeError):
@@ -266,12 +284,13 @@ class Test_astartes(unittest.TestCase):
                     test_size=None,
                 )
         with self.subTest("val_size w/ valid test_size"):
-            train_val_test_split(
-                self.X,
-                train_size=None,
-                val_size=0.4,
-                test_size=0.2,
-            )
+            with self.assertRaises(ImperfectSplittingWarning):
+                train_val_test_split(
+                    self.X,
+                    train_size=None,
+                    val_size=0.4,
+                    test_size=0.2,
+                )
         with self.subTest("val_size w/ invalid test_size"):
             with self.assertRaises(RuntimeError):
                 train_val_test_split(
@@ -281,13 +300,12 @@ class Test_astartes(unittest.TestCase):
                     test_size=2,
                 )
         with self.subTest("val_size w/ valid train_size"):
-            with self.assertWarns(ImperfectSplittingWarning):
-                train_val_test_split(
-                    self.X,
-                    train_size=0.2,
-                    val_size=0.4,
-                    test_size=None,
-                )
+            train_val_test_split(
+                self.X,
+                train_size=0.2,
+                val_size=0.4,
+                test_size=None,
+            )
         with self.subTest("val_size w/ invalid train_size"):
             with self.assertRaises(RuntimeError):
                 train_val_test_split(
@@ -366,8 +384,48 @@ class Test_astartes(unittest.TestCase):
                     "random_state": 42,
                 },
             )
-            for elt, ans in zip(X_train.flatten(), [7, 8, 9, 1, 2, 3]):
-                self.assertEqual(elt, ans)
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    X_train,
+                    np.array([[4, 5, 6]]),
+                    "X_train incorrect.",
+                ),
+            )
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    X_test,
+                    np.array([[7, 8, 9], [1, 2, 3]]),
+                    "X_test incorrect.",
+                ),
+            )
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    y_train,
+                    np.array([11]),
+                    "y_train incorrect.",
+                ),
+            )
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    y_test,
+                    np.array([12, 10]),
+                    "y_test incorrect.",
+                ),
+            )
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    labels_train,
+                    np.array(["banana"]),
+                    "labels_train incorrect.",
+                ),
+            )
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    labels_test,
+                    np.array(["apple", "apple"]),
+                    "labels_test incorrect.",
+                ),
+            )
 
     def test_return_indices(self):
         """Test the ability to return the indices and not the values."""
@@ -384,8 +442,13 @@ class Test_astartes(unittest.TestCase):
                 },
                 return_indices=True,
             )
-            for elt, ans in zip(indices_train.flatten(), [2, 0]):
-                self.assertEqual(elt, ans)
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    indices_test,
+                    np.array([2, 0]),
+                    "Test indices incorrect.",
+                ),
+            )
 
     def test_return_indices_with_validation(self):
         """Test the ability to return indices in train_val_test_split"""
@@ -396,15 +459,20 @@ class Test_astartes(unittest.TestCase):
                 labels=np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 test_size=0.33,
                 val_size=0.33,
-                train_size=0.33,
+                train_size=0.34,
                 sampler="random",
                 hopts={
                     "random_state": 42,
                 },
                 return_indices=True,
             )
-            for elt, ans in zip(indices_val.flatten(), [8, 2]):
-                self.assertEqual(elt, ans)
+            self.assertIsNone(
+                np.testing.assert_array_equal(
+                    indices_val,
+                    np.array([8, 2]),
+                    "Validation indices incorrect.",
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/test/utils/test_sampler_factory.py
+++ b/test/utils/test_sampler_factory.py
@@ -23,12 +23,13 @@ class Test_sampler_factory(unittest.TestCase):
                 [1, 1, 1],
             ]
         )
+        self.y = np.array([1, 2, 3])
 
     def test_train_test_split(self):
         """Call sampler factory on all inputs."""
         for sampler_name in ALL_SAMPLERS:
             test_factory = SamplerFactory(sampler_name)
-            test_instance = test_factory.get_sampler(self.X, None, None, {})
+            test_instance = test_factory.get_sampler(self.X, self.y, None, {})
             self.assertIsInstance(
                 test_instance,
                 AbstractSampler,


### PR DESCRIPTION
 - this PR adds the interpolative sampling algorithm, resolves #27 
 - also fixes a significant bug in the way interpolative sampling was being done by the main function, which was operating under the false assumption that the results from kennard stone and spxy were given inside-out