### PR TITLE
Improve scaffold

### DIFF
--- a/astartes/samplers/extrapolation/scaffold.py
+++ b/astartes/samplers/extrapolation/scaffold.py
@@ -34,7 +34,7 @@ class Scaffold(AbstractSampler):
         """Implements the Scaffold sampler to identify clusters via a molecule's Bemis-Murcko scaffold."""
         scaffold_to_indices = self.scaffold_to_smiles(self.X)
 
-        cluster_indices = np.zeros(len(self.X), dtype=np.int8)
+        cluster_indices = np.empty(len(self.X), dtype=object)
         # give each cluster an arbitrary ID
         for cluster_id, (scaffold, indices) in enumerate(scaffold_to_indices.items()):
             if scaffold == "":
@@ -44,7 +44,7 @@ class Scaffold(AbstractSampler):
                     NoMatchingScaffold,
                 )
             for idx in indices:
-                cluster_indices[idx] = cluster_id
+                cluster_indices[idx] = scaffold
 
         self._samples_clusters = cluster_indices
 

--- a/test/samplers/test_Scaffold.py
+++ b/test/samplers/test_Scaffold.py
@@ -16,12 +16,13 @@ class Test_scaffold(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         """Convenience attributes for later tests."""
+        # scaffold only contains the ring structure, not the side chains
         self.X = np.array(
             [
-                "c1ccccc1",
-                "O=C1NCCO1",
-                "O=C1CCCCCN1",
-                "C1CCNCC1",
+                "c1ccccc1CC",       # scaffold is c1ccccc1
+                "O=C1NCCO1",        # scaffold is O=C1NCCO1
+                "O=C1CCC(CC)CCN1",  # scaffold is O=C1CCCCCN1
+                "C1CCNCC1CC",       # scaffold is C1CCNCC1
             ]
         )
         self.X_inchi = np.array(
@@ -65,14 +66,14 @@ class Test_scaffold(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
-                np.array(["O=C1NCCO1", "O=C1CCCCCN1", "C1CCNCC1"]),
+                np.array(["O=C1NCCO1", "O=C1CCC(CC)CCN1", "C1CCNCC1CC"]),
             ),
             "Train X incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array(["c1ccccc1"]),
+                np.array(["c1ccccc1CC"]),
             ),
             "Test X incorrect.",
         )
@@ -107,14 +108,14 @@ class Test_scaffold(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 clusters_train,
-                np.array([1, 2, 3]),
+                np.array(['O=C1NCCO1', 'O=C1CCCCCN1', 'C1CCNCC1']),
             ),
             "Train clusters incorrect.",
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 clusters_test,
-                np.array([0]),
+                np.array(['c1ccccc1']),
             ),
             "Test clusters incorrect.",
         )


### PR DESCRIPTION
This PR improves the scaffold sampler. Previously, the cluster labels were assigned arbitrary indices to copy the behavior of KMeans, DBSCAN, etc. However, since this sampler is chemically motivated, it is probably more informative to a user to see "these molecules correspond to scaffold `c1ccccc1`" rather than "these molecules correspond to cluster 0" for example and then having to backtrack and figure out which scaffold cluster 0 corresponds to. This PR updates the scaffold sampler and corresponding unit tests to provide this information to the user.