### PR TITLE
Allow users to access the power hyperparameter for DBSCAN

### DIFF
--- a/astartes/samplers/extrapolation/dbscan.py
+++ b/astartes/samplers/extrapolation/dbscan.py
@@ -21,5 +21,6 @@ class DBSCAN(AbstractSampler):
             metric=self.get_config("metric", "euclidean"),
             algorithm=self.get_config("algorithm", "auto"),
             leaf_size=self.get_config("leaf_size", 30),
+            p=self.get_config("p", None),
         ).fit(self.X)
         self._samples_clusters = dbscan.labels_


### PR DESCRIPTION
This PR makes the `p` argument in DBSCAN accessible to users. Technically, we could also surface the `n_jobs` argument. However, I don't believe this is shared with other sklearn clustering functions (or with any of the other samplers in astartes) so I didn't see a point for now. Happy to revisit parallelization in a future PR though.

