### PR TITLE
Change behavior of `return_indices`

### DIFF
--- a/astartes/main.py
+++ b/astartes/main.py
@@ -39,7 +39,7 @@ def train_val_test_split(
         sampler (str, optional): Sampler to use, see IMPLEMENTED_INTER/EXTRAPOLATION_SAMPLERS. Defaults to "random".
         random_state (int, optional): The random seed used throughout astartes.
         hopts (dict, optional): Hyperparameters for the sampler used above. Defaults to {}.
-        return_indices (bool, optional): True to return indices of train/test instead of values. Defaults to False.
+        return_indices (bool, optional): True to return indices of train/test after values. Defaults to False.
 
     Returns:
         np.array: X, y, and labels train/val/test data, or indices.
@@ -231,16 +231,11 @@ def _return_helper(
         test_size (float): Fraction of data to use in test.
         val_size (float): Fraction of data to use in val.
         train_size (float): Fraction of data to use in train.
-        return_indices (bool): Return indices or the arrays themselves.
+        return_indices (bool): Return indices after the value arrays.
 
     Returns:
         np.array: Either many arrays or indices in arrays.
     """
-    if return_indices:
-        if val_idxs.any():
-            return train_idxs, val_idxs, test_idxs
-        else:
-            return train_idxs, test_idxs
     out = []
     X_train = sampler_instance.X[train_idxs]
     out.append(X_train)
@@ -274,7 +269,11 @@ def _return_helper(
             out.append(clusters_val)
         clusters_test = sampler_instance.get_clusters()[test_idxs]
         out.append(clusters_test)
-
+    if return_indices:
+        out.append(train_idxs)
+        if val_idxs.any():
+            out.append(val_idxs)
+        out.append(test_idxs)
     return (*out,)
 
 

--- a/astartes/molecules.py
+++ b/astartes/molecules.py
@@ -53,7 +53,7 @@ def train_val_test_split_molecules(
         hopts (dict, optional): Hyperparameters for the sampler used above. Defaults to {}.
         fingerprint (str, optional): Molecular fingerprint to be used from AIMSim. Defaults to "morgan_fingerprint".
         fprints_hopts (dict, optional): Hyperparameters for AIMSim featurization. Defaults to {}.
-        return_indices (bool, optional): True to return indices of train/test instead of values. Defaults to False.
+        return_indices (bool, optional): True to return indices of train/test after the values. Defaults to False.
 
     Returns:
         np.array: X, y, and labels train/val/test data, or indices.
@@ -99,7 +99,7 @@ def train_test_split_molecules(
         hopts (dict, optional): Hyperparameters for the sampler used above. Defaults to {}.
         fingerprint (str, optional): Molecular fingerprint to be used from AIMSim. Defaults to "morgan_fingerprint".
         fprints_hopts (dict, optional): Hyperparameters for AIMSim featurization. Defaults to {}.
-        return_indices (bool, optional): True to return indices of train/test instead of values. Defaults to False.
+        return_indices (bool, optional): True to return indices of train/test after the values. Defaults to False.
 
     Returns:
         np.array: X, y, and labels train/test data, or indices.

--- a/examples/RDB7_barrier_prediction_example.ipynb
+++ b/examples/RDB7_barrier_prediction_example.ipynb
@@ -491,7 +491,7 @@
    "source": [
     "def train_model(seed, sampler, hopts={}, df_r_fp=df_r_fp):\n",
     "    # use random splits to create 85:5:10 data split\n",
-    "    train_indices, val_indices, test_indices = train_val_test_split(df_r_fp.values,\n",
+    "    _,_,_, train_indices, val_indices, test_indices = train_val_test_split(df_r_fp.values,\n",
     "                                                                    train_size=0.85,\n",
     "                                                                    val_size=0.05,\n",
     "                                                                    test_size=0.1,\n",

--- a/sklearn_to_astartes.md
+++ b/sklearn_to_astartes.md
@@ -79,7 +79,7 @@ X_train, X_test, y_train, y_test = train_test_split(
 ## Step 5. Useful `astartes` Features
 
 ### `return_indices`: Improve Code Clarity
-When providing `X`, `y`, and `labels` it can become cumbersome to unpack all of arrays, and there are cirumstances where the indices of the train/test data can be useful (for example, if `y` or `labels` are large, memory-intense objects). By default, `astartes` will return the arrays themselves, but it can also return just the indices for the user to manipulate according to their needs:
+There are circumstances where the indices of the train/test data can be useful (for example, if `y` or `labels` are large, memory-intense objects), and there is no way to directly return these indices in `sklearn`. `astartes` will return the sampling splits themselves by default, but it can also return the indices for the user to manipulate according to their needs:
 ```python
 X_train, X_test, y_train, y_test, labels_train, labels_test = train_test_split(
     X,
@@ -90,13 +90,15 @@ X_train, X_test, y_train, y_test, labels_train, labels_test = train_test_split(
 ```
 _could instead be_
 ```python
-indices_train, indices_test = train_test_split(
+X_train, X_test, y_train, y_test, labels_train, labels_test, indices_train, indices_test = train_test_split(
     X,
     y,
     labels,
     return_indices = True,
 )
 ```
+If `y` or `labels` were large, memory-intense objects it could be beneficial to _not_ pass them in to `train_test_split` and instead separate the existing lists later using the returned indices.
+
 ### `train_val_test_split`: More Rigorous ML
 Behind the scenes, `train_test_split` is actually just a one-line function that calls the real workhorse of `astartes` - `train_val_test_split`:
 ```python

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -421,8 +421,8 @@ class Test_astartes(unittest.TestCase):
                 test_y,
                 train_labels,
                 test_labels,
-                indices_train,
-                indices_test,
+                train_indices,
+                test_indices,
             ) = train_test_split(
                 np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
                 np.array([10, 11, 12]),
@@ -435,7 +435,7 @@ class Test_astartes(unittest.TestCase):
             )
             self.assertIsNone(
                 np.testing.assert_array_equal(
-                    indices_test,
+                    test_indices,
                     np.array([2, 0]),
                     "Test indices incorrect.",
                 ),
@@ -454,9 +454,9 @@ class Test_astartes(unittest.TestCase):
                 train_labels,
                 val_labels,
                 test_labels,
-                indices_train,
-                indices_val,
-                indices_test,
+                train_indices,
+                val_indices,
+                test_indices,
             ) = train_val_test_split(
                 np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
@@ -470,7 +470,7 @@ class Test_astartes(unittest.TestCase):
             )
             self.assertIsNone(
                 np.testing.assert_array_equal(
-                    indices_val,
+                    val_indices,
                     np.array([8, 2]),
                     "Validation indices incorrect.",
                 ),

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -412,9 +412,18 @@ class Test_astartes(unittest.TestCase):
             )
 
     def test_return_indices(self):
-        """Test the ability to return the indices and not the values."""
+        """Test the ability to return the indices and the values."""
         with self.assertWarns(ImperfectSplittingWarning):
-            (indices_train, indices_test,) = train_test_split(
+            (
+                train_X,
+                test_X,
+                train_y,
+                test_y,
+                train_labels,
+                test_labels,
+                indices_train,
+                indices_test,
+            ) = train_test_split(
                 np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
                 np.array([10, 11, 12]),
                 labels=np.array(["apple", "banana", "apple"]),
@@ -435,7 +444,20 @@ class Test_astartes(unittest.TestCase):
     def test_return_indices_with_validation(self):
         """Test the ability to return indices in train_val_test_split"""
         with self.assertWarns(ImperfectSplittingWarning):
-            (indices_train, indices_val, indices_test,) = train_val_test_split(
+            (
+                train_X,
+                val_X,
+                test_X,
+                train_y,
+                val_y,
+                test_y,
+                train_labels,
+                val_labels,
+                test_labels,
+                indices_train,
+                indices_val,
+                indices_test,
+            ) = train_val_test_split(
                 np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 labels=np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]),


### PR DESCRIPTION
Currently, `return_indices` will replace the valued arrays rather than just append the indices to the end, which is unhelpful in some circumstances. This PR changes the behavior of `return_indices` to append the train, validation, and testing indices to the output arrays if the keyword argument is true.

Related to #91 