### PR TITLE
Implement `random_state` effect in extrapolative cluster assignment

### DIFF
--- a/astartes/main.py
+++ b/astartes/main.py
@@ -245,14 +245,14 @@ def _return_helper(
         np.array: Either many arrays or indices in arrays.
     """
     if return_indices:
-        if val_idxs.any():
+        if len(val_idxs):
             return train_idxs, val_idxs, test_idxs
         else:
             return train_idxs, test_idxs
     out = []
     X_train = sampler_instance.X[train_idxs]
     out.append(X_train)
-    if val_idxs.any():
+    if len(val_idxs):
         X_val = sampler_instance.X[val_idxs]
         out.append(X_val)
     X_test = sampler_instance.X[test_idxs]
@@ -261,7 +261,7 @@ def _return_helper(
     if sampler_instance.y is not None:
         y_train = sampler_instance.y[train_idxs]
         out.append(y_train)
-        if val_idxs.any():
+        if len(val_idxs):
             y_val = sampler_instance.y[val_idxs]
             out.append(y_val)
         y_test = sampler_instance.y[test_idxs]
@@ -269,7 +269,7 @@ def _return_helper(
     if sampler_instance.labels is not None:
         labels_train = sampler_instance.labels[train_idxs]
         out.append(labels_train)
-        if val_idxs.any():
+        if len(val_idxs):
             labels_val = sampler_instance.labels[val_idxs]
             out.append(labels_val)
         labels_test = sampler_instance.labels[test_idxs]
@@ -277,7 +277,7 @@ def _return_helper(
     if len(sampler_instance.get_clusters()):  # true when the list has been filled
         clusters_train = sampler_instance.get_clusters()[train_idxs]
         out.append(clusters_train)
-        if val_idxs.any():
+        if len(val_idxs):
             clusters_val = sampler_instance.get_clusters()[val_idxs]
             out.append(clusters_val)
         clusters_test = sampler_instance.get_clusters()[test_idxs]

--- a/astartes/samplers/abstract_sampler.py
+++ b/astartes/samplers/abstract_sampler.py
@@ -114,3 +114,6 @@ class AbstractSampler(ABC):
         # and will instead sort by the value of the cluster labels (wrong!)
         self._samples_idxs = np.array(sorted_idxs, dtype=int)
         self._sorted_cluster_counter = sorted_cluster_counter
+
+    def get_semi_sorted_cluster_counter(self, max_shufflable_size):
+        pass

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -193,10 +193,10 @@ class Test_astartes(unittest.TestCase):
                 self.y,
                 labels=self.labels,
                 test_size=0.1,
-                val_size=0.2,
-                train_size=0.7,
+                val_size=0.1,
+                train_size=0.8,
                 sampler="sphere_exclusion",
-                random_state=8_675_309,
+                random_state=1234,
             )
             self.assertFalse(
                 len(w),
@@ -208,31 +208,19 @@ class Test_astartes(unittest.TestCase):
                     ),
                 ),
             )
-        print(
-            X_train,
-            X_val,
-            X_test,
-            y_train,
-            y_val,
-            y_test,
-            labels_train,
-            labels_val,
-            labels_test,
-            clusters_train,
-            clusters_val,
-            clusters_test,
-        )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_train,
                 np.array(
                     [
                         [1, 0, 0, 0, 0],
-                        [1, 0, 0, 0, 0],
-                        [0, 0, 0, 0, 0],
-                        [1, 1, 1, 0, 0],
                         [1, 1, 0, 0, 0],
-                        [1, 1, 1, 1, 1],
+                        [1, 1, 1, 0, 0],
+                        [1, 1, 1, 1, 0],
+                        [1, 0, 0, 0, 0],
+                        [1, 1, 0, 0, 0],
+                        [1, 1, 1, 0, 0],
+                        [1, 1, 1, 1, 0],
                     ]
                 ),
                 "Train X incorrect.",
@@ -241,56 +229,56 @@ class Test_astartes(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_val,
-                np.array([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]]),
+                np.array([[0, 0, 0, 0, 0]]),
                 "Validation X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 X_test,
-                np.array([[1, 1, 0, 0, 0], [1, 1, 1, 1, 0]]),
+                np.array([[1, 1, 1, 1, 1]]),
                 "Test X incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([2, 6, 1, 8, 3, 10]),
+                np.array([2, 3, 4, 5, 6, 7, 8, 9]),
                 "Train y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_val,
-                np.array([5, 4]),
+                np.array([1]),
                 "Validation y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_test,
-                np.array([7, 9]),
+                np.array([10]),
                 "Test y incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["two", "six", "one", "eight", "three", "ten"]),
+                np.array(["two" "three" "four" "five" "six" "seven" "eight" "nine"]),
                 "Train labels incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_val,
-                np.array(["five", "four"]),
+                np.array(["one"]),
                 "Validation labels incorrect.",
             )
         )
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_test,
-                np.array(["seven", "nine"]),
+                np.array(["ten"]),
                 "Test labels incorrect.",
             )
         )

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -171,6 +171,130 @@ class Test_astartes(unittest.TestCase):
             )
         )
 
+    def test_train_val_test_split_extrpolation_shuffling(self):
+        """Split data into training, validation, and test sets with shuffling."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always")
+            (
+                X_train,
+                X_val,
+                X_test,
+                y_train,
+                y_val,
+                y_test,
+                labels_train,
+                labels_val,
+                labels_test,
+                clusters_train,
+                clusters_val,
+                clusters_test,
+            ) = train_val_test_split(
+                self.X,
+                self.y,
+                labels=self.labels,
+                test_size=0.1,
+                val_size=0.2,
+                train_size=0.7,
+                sampler="sphere_exclusion",
+                random_state=8_675_309,
+            )
+            self.assertFalse(
+                len(w),
+                "\nNo warnings should have been raised when requesting a mathematically possible split."
+                "\nReceived {:d} warnings instead: \n -> {:s}".format(
+                    len(w),
+                    "\n -> ".join(
+                        [str(i.category.__name__) + ": " + str(i.message) for i in w]
+                    ),
+                ),
+            )
+        print(
+            X_train,
+            X_val,
+            X_test,
+            y_train,
+            y_val,
+            y_test,
+            labels_train,
+            labels_val,
+            labels_test,
+            clusters_train,
+            clusters_val,
+            clusters_test,
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_train,
+                np.array(
+                    [
+                        [1, 0, 0, 0, 0],
+                        [1, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [1, 1, 1, 0, 0],
+                        [1, 1, 0, 0, 0],
+                        [1, 1, 1, 1, 1],
+                    ]
+                ),
+                "Train X incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_val,
+                np.array([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]]),
+                "Validation X incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                X_test,
+                np.array([[1, 1, 0, 0, 0], [1, 1, 1, 1, 0]]),
+                "Test X incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_train,
+                np.array([2, 6, 1, 8, 3, 10]),
+                "Train y incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_val,
+                np.array([5, 4]),
+                "Validation y incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                y_test,
+                np.array([7, 9]),
+                "Test y incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_train,
+                np.array(["two", "six", "one", "eight", "three", "ten"]),
+                "Train labels incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_val,
+                np.array(["five", "four"]),
+                "Validation labels incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                labels_test,
+                np.array(["seven", "nine"]),
+                "Test labels incorrect.",
+            )
+        )
+
     def test_insufficient_dataset_train(self):
         """If the user requests a split that would result in rounding down the size of the
         test set to zero, a helpful exception should be raised."""

--- a/test/test_astartes.py
+++ b/test/test_astartes.py
@@ -196,7 +196,7 @@ class Test_astartes(unittest.TestCase):
                 val_size=0.1,
                 train_size=0.8,
                 sampler="sphere_exclusion",
-                random_state=1234,
+                random_state=867_5309,
             )
             self.assertFalse(
                 len(w),
@@ -214,12 +214,12 @@ class Test_astartes(unittest.TestCase):
                 np.array(
                     [
                         [1, 0, 0, 0, 0],
-                        [1, 1, 0, 0, 0],
-                        [1, 1, 1, 0, 0],
-                        [1, 1, 1, 1, 0],
                         [1, 0, 0, 0, 0],
                         [1, 1, 0, 0, 0],
+                        [1, 1, 0, 0, 0],
                         [1, 1, 1, 0, 0],
+                        [1, 1, 1, 0, 0],
+                        [1, 1, 1, 1, 0],
                         [1, 1, 1, 1, 0],
                     ]
                 ),
@@ -243,7 +243,7 @@ class Test_astartes(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 y_train,
-                np.array([2, 3, 4, 5, 6, 7, 8, 9]),
+                np.array([2, 6, 3, 7, 4, 8, 5, 9]),
                 "Train y incorrect.",
             )
         )
@@ -264,7 +264,9 @@ class Test_astartes(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_array_equal(
                 labels_train,
-                np.array(["two" "three" "four" "five" "six" "seven" "eight" "nine"]),
+                np.array(
+                    ["two", "six", "three", "seven", "four", "eight", "five", "nine"]
+                ),
                 "Train labels incorrect.",
             )
         )
@@ -280,6 +282,27 @@ class Test_astartes(unittest.TestCase):
                 labels_test,
                 np.array(["ten"]),
                 "Test labels incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                clusters_train,
+                np.array([4, 4, 0, 0, 1, 1, 5, 5]),
+                "Train cluster assignments incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                clusters_val,
+                np.array([2]),
+                "Validation cluster assignments incorrect.",
+            )
+        )
+        self.assertIsNone(
+            np.testing.assert_array_equal(
+                clusters_test,
+                np.array([3]),
+                "Test cluster assignments incorrect.",
             )
         )
 


### PR DESCRIPTION
This PR resolves #80 by implementing an additional function in `AbstractSampler` that will shuffle around the order of the smallest clusters in the dataset, which means on repeat execution with a different `random_seed` slightly different splits will be made (different clusters will be assigned to testing and validation, but training will keep the same assignments).