### PR TITLE
add support for X, y, and labels of type other than np.ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default, `astartes` will split data randomly. Additionally, a variety of algo
 
 ```python
 X_train, X_test, y_train, y_test = train_test_split(
-  X,
+  X,  # preferably numpy arrays, but astartes will cast it for you
   y,
   sampler = 'kennard_stone',  # any of the supported samplers
 )

--- a/astartes/main.py
+++ b/astartes/main.py
@@ -7,6 +7,7 @@ from astartes.samplers import (
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
+from astartes.utils.convert_to_array import convert_to_array
 from astartes.utils.exceptions import InvalidConfigurationError
 from astartes.utils.sampler_factory import SamplerFactory
 from astartes.utils.warnings import ImperfectSplittingWarning, NormalizationWarning
@@ -44,6 +45,13 @@ def train_val_test_split(
     Returns:
         np.array: X, y, and labels train/val/test data, or indices.
     """
+    if type(X) is not np.ndarray:
+        X = convert_to_array(X, "X")
+    if y is not None and type(y) is not np.ndarray:
+        y = convert_to_array(y, "y")
+    if labels is not None and type(labels) is not np.ndarray:
+        labels = convert_to_array(labels, "labels")
+
     msg = ""
     if y is not None and len(y) != len(X):
         msg += "len(y)={:d} ".format(len(y))

--- a/astartes/utils/convert_to_array.py
+++ b/astartes/utils/convert_to_array.py
@@ -1,8 +1,9 @@
 import warnings
+from datetime import date, datetime
 
 import numpy as np
 
-from astartes.utils.exceptions import UncastableInputError
+from astartes.utils.exceptions import InvalidConfigurationError, UncastableInputError
 from astartes.utils.warnings import ConversionWarning
 
 
@@ -26,5 +27,14 @@ def convert_to_array(obj: object, name: str):
         raise UncastableInputError(
             "Unable to cast {:s} to a numpy array using np.asarray."
         ) from e
+    # ensure that all the values in the array are floats or date/datetime objects
+    for item in new_array.ravel():
+        if type(item) not in (float, np.float_, int, np.int_, date, datetime):
+            raise InvalidConfigurationError(
+                "After casting, input object {:s} contained unsupported type {:s}".format(
+                    name,
+                    str(type(item)),
+                )
+            )
 
     return new_array

--- a/astartes/utils/convert_to_array.py
+++ b/astartes/utils/convert_to_array.py
@@ -1,0 +1,30 @@
+import warnings
+
+import numpy as np
+
+from astartes.utils.exceptions import UncastableInputError
+from astartes.utils.warnings import ConversionWarning
+
+
+def convert_to_array(obj: object, name: str):
+    """Attempt to convert obj named name to a numpy array, with appropriate warnings and exceptions.
+
+    Args:
+        obj (object): The item to attempt to convert.
+        name (str): Human-readable name for printing.
+    """
+    warnings.warn(
+        "Attempting to cast {:s} to a numpy array, which may result in unexpected behavior "
+        "(remove this warning by passing numpy arrays directly to astartes).".format(
+            name,
+        ),
+        ConversionWarning,
+    )
+    try:
+        new_array = np.asarray(obj)
+    except Exception as e:
+        raise UncastableInputError(
+            "Unable to cast {:s} to a numpy array using np.asarray."
+        ) from e
+
+    return new_array

--- a/astartes/utils/exceptions.py
+++ b/astartes/utils/exceptions.py
@@ -23,3 +23,11 @@ class SamplerNotImplementedError(RuntimeError):
     def __init__(self, message=None):
         self.message = message
         super().__init__(message)
+
+
+class UncastableInputError(RuntimeError):
+    """Used when X, y, or labels cannot be cast to a np.array."""
+
+    def __init__(self, message=None):
+        self.message = message
+        super().__init__(message)

--- a/astartes/utils/warnings.py
+++ b/astartes/utils/warnings.py
@@ -17,6 +17,14 @@ class NormalizationWarning(RuntimeWarning):
         super().__init__(message)
 
 
+class ConversionWarning(RuntimeWarning):
+    """Used when passed data is not a numpy array."""
+
+    def __init__(self, message=None):
+        self.message = message
+        super().__init__(message)
+
+
 class NoMatchingScaffold(Warning):
     """
     Used when an RDKit molecule does not match any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astartes"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     { name = "Jackson Burns", email = "jwburns@mit.edu" },
     { name = "Himaghna Bhattacharjee", email = "himaghna@udel.edu" },

--- a/test/unit/utils/test_convert_to_array.py
+++ b/test/unit/utils/test_convert_to_array.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 from astartes import train_val_test_split
-from astartes.utils.exceptions import UncastableInputError
+from astartes.utils.exceptions import UncastableInputError, InvalidConfigurationError
 from astartes.utils.warnings import ConversionWarning
 
 
@@ -13,6 +13,13 @@ class Test_convert_to_array(unittest.TestCase):
     """
     Test convert to numpy array for failures.
     """
+
+    def test_bad_type_cast(self):
+        """Raise error when casting arrays that do not contain supported types."""
+        with self.assertRaises(InvalidConfigurationError):
+            train_val_test_split(
+                ["cat", "dog"],
+            )
 
     def test_convertable_input(self):
         """Raise warning when casting."""

--- a/test/unit/utils/test_convert_to_array.py
+++ b/test/unit/utils/test_convert_to_array.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 from astartes import train_val_test_split
-from astartes.utils.exceptions import UncastableInputError, InvalidConfigurationError
+from astartes.utils.exceptions import InvalidConfigurationError, UncastableInputError
 from astartes.utils.warnings import ConversionWarning
 
 

--- a/test/unit/utils/test_convert_to_array.py
+++ b/test/unit/utils/test_convert_to_array.py
@@ -25,11 +25,17 @@ class Test_convert_to_array(unittest.TestCase):
                 val_size=0.25,
             )
 
+    @unittest.skipIf(
+        sys.version_info.minor == 7,
+        "Versions of numpy compatible with Python 3.7 will convert ANYTHING "
+        "into an array (thus the warning in convert_to_array, and skip test)",
+    )
     def test_unconvertable_input(self):
         """Raise error when casting fails."""
         with self.assertRaises(UncastableInputError):
+            # inhomogeneous lists w/ mixed types cannot be cast to arrays
             train_val_test_split(
-                [[1], [1, 2]],  # inhomogeneous lists cannot be cast to arrays
+                [[1], [1, 2]],
             )
 
 

--- a/test/unit/utils/test_convert_to_array.py
+++ b/test/unit/utils/test_convert_to_array.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+
+from astartes import train_val_test_split
+from astartes.utils.exceptions import UncastableInputError
+from astartes.utils.warnings import ConversionWarning
+
+
+class Test_convert_to_array(unittest.TestCase):
+    """
+    Test convert to numpy array for failures.
+    """
+
+    def test_convertable_input(self):
+        """Raise warning when casting."""
+        with self.assertWarns(ConversionWarning):
+            train_val_test_split(
+                [[1, 2], [3, 4], [5, 6], [7, 8]],
+                [1, 2, 3, 4],
+                train_size=0.50,
+                test_size=0.25,
+                val_size=0.25,
+            )
+
+    def test_unconvertable_input(self):
+        """Raise error when casting fails."""
+        with self.assertRaises(UncastableInputError):
+            train_val_test_split(
+                [[1], [1, 2]],  # inhomogeneous lists cannot be cast to arrays
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently `astartes` only includes type hints to indicate that `X`, `y`, and `labels` should be numpy arrays, but it is not enforced and can lead to unexpected behavior. This PR adds a new function, `convert_to_numpy_array` in `astartes.utils` which will attempt to convert inputs to the appropriate type. Users are warned during this process so that they may ensure the conversion is correct, and a helpful exception is raised if the conversion is not possible.

I have also added a brief update to the README, and new unit tests for this functionality.

This PR resolves #123 