### PR TITLE
Improve Performance of Kennard-Stone, SPXY Samplers

### DIFF
--- a/astartes/samplers/interpolation/kennardstone.py
+++ b/astartes/samplers/interpolation/kennardstone.py
@@ -2,7 +2,6 @@ import numpy as np
 from scipy.spatial.distance import pdist, squareform
 
 from astartes.samplers import AbstractSampler
-from astartes.utils.exceptions import InvalidConfigurationError
 
 
 class KennardStone(AbstractSampler):
@@ -20,31 +19,40 @@ class KennardStone(AbstractSampler):
         X_dist = pdist(self.X, metric=distance_metric)
 
         ks_distance = squareform(X_dist)
+        # when searching for max distance, disregard self
         np.fill_diagonal(ks_distance, -np.inf)
+
+        # delete from distance as we go, keep this array to keep track of idxs
+        ks_idxs = np.arange(n_samples)
 
         # get the row/col of maximum (greatest distance)
         max_idx = np.nanargmax(ks_distance)
         max_coords = np.unravel_index(max_idx, ks_distance.shape)
 
-        # -np.inf these points to trick numpy later on
-        ks_distance[max_coords[0], :] = -np.inf
-        ks_distance[max_coords[1], :] = -np.inf
+        # delete these rows so we don't select them again
+        ks_distance = np.delete(
+            ks_distance,
+            max_coords,
+            axis=0,
+        )
+        # delete from the index list to track deletions in distance matrix
+        ks_idxs = np.delete(ks_idxs, max_coords)
 
         # list of indices which have been selected, for use in the below loop
-        already_selected = list()
-        already_selected.append(max_coords[0])
-        already_selected.append(max_coords[1])
+        already_selected = list(max_coords)
 
         # iterate through the rest
         for _ in range(n_samples - 2):
             # find the next sample with the largest minimum distance to any sample already selected
-            # get out the columns for the data already selected
-            select_ks_distance = ks_distance[:, already_selected]
-            # find which member of the selected data each of the unselected data is closest to
-            min_distances_vals = np.nanmin(select_ks_distance, axis=1)
-            # pick the largest of those values
-            max_min_idx = np.nanargmax(min_distances_vals)
-            ks_distance[max_min_idx, :] = -np.inf
-            already_selected.append(max_min_idx)
+            max_min_idx = np.argmax(
+                np.min(
+                    ks_distance[:, already_selected],
+                    axis=1,
+                )  # find which member of the selected data each of the unselected data is closest to
+            )  # pick the largest of those values
+            # add to the selected, remove from index tracker and distance matrix
+            ks_distance = np.delete(ks_distance, max_min_idx, axis=0)
+            already_selected.append(ks_idxs[max_min_idx])
+            ks_idxs = np.delete(ks_idxs, max_min_idx)
 
         self._samples_idxs = np.array(already_selected, dtype=int)

--- a/astartes/samplers/interpolation/kennardstone.py
+++ b/astartes/samplers/interpolation/kennardstone.py
@@ -15,44 +15,27 @@ class KennardStone(AbstractSampler):
         n_samples = len(self.X)
 
         distance_metric = self.get_config("metric", "euclidean")
-
         X_dist = pdist(self.X, metric=distance_metric)
-
         ks_distance = squareform(X_dist)
         # when searching for max distance, disregard self
         np.fill_diagonal(ks_distance, -np.inf)
-
-        # delete from distance as we go, keep this array to keep track of idxs
-        ks_idxs = np.arange(n_samples)
 
         # get the row/col of maximum (greatest distance)
         max_idx = np.nanargmax(ks_distance)
         max_coords = np.unravel_index(max_idx, ks_distance.shape)
 
-        # delete these rows so we don't select them again
-        ks_distance = np.delete(
-            ks_distance,
-            max_coords,
-            axis=0,
-        )
-        # delete from the index list to track deletions in distance matrix
-        ks_idxs = np.delete(ks_idxs, max_coords)
-
-        # list of indices which have been selected, for use in the below loop
+        # list of indices which have been selected
+        # - used to mask ks_distance
+        # - also tracks order of kennard-stone selection
         already_selected = list(max_coords)
+
+        # minimum distance of all unselected samples to the two selected samples
         min_distances = np.min(ks_distance[:, already_selected], axis=1)
-        # print(min_distances)
         for _ in range(n_samples - 2):
-            # print("already have", self.X[already_selected])
             # find the next sample with the largest minimum distance to any sample already selected
-            max_min_idx = np.argmax(min_distances)
-            # add to the selected, remove from index tracker and distance matrix
-            ks_distance = np.delete(ks_distance, max_min_idx, axis=0)
-            already_selected.append(ks_idxs[max_min_idx])
-            ks_idxs = np.delete(ks_idxs, max_min_idx)
-            # update the minimum distances array
-            # delete the sample we just selected
-            min_distances = np.delete(min_distances, max_min_idx)
+            already_selected.append(
+                np.argmax(min_distances),
+            )
             # get minimum distance of unselected samples to that sample only
             new_distances = np.min(ks_distance[:, [already_selected[-1]]], axis=1)
             min_distances = np.minimum(min_distances, new_distances)

--- a/astartes/samplers/interpolation/kennardstone.py
+++ b/astartes/samplers/interpolation/kennardstone.py
@@ -40,19 +40,21 @@ class KennardStone(AbstractSampler):
 
         # list of indices which have been selected, for use in the below loop
         already_selected = list(max_coords)
-
-        # iterate through the rest
+        min_distances = np.min(ks_distance[:, already_selected], axis=1)
+        # print(min_distances)
         for _ in range(n_samples - 2):
+            # print("already have", self.X[already_selected])
             # find the next sample with the largest minimum distance to any sample already selected
-            max_min_idx = np.argmax(
-                np.min(
-                    ks_distance[:, already_selected],
-                    axis=1,
-                )  # find which member of the selected data each of the unselected data is closest to
-            )  # pick the largest of those values
+            max_min_idx = np.argmax(min_distances)
             # add to the selected, remove from index tracker and distance matrix
             ks_distance = np.delete(ks_distance, max_min_idx, axis=0)
             already_selected.append(ks_idxs[max_min_idx])
             ks_idxs = np.delete(ks_idxs, max_min_idx)
+            # update the minimum distances array
+            # delete the sample we just selected
+            min_distances = np.delete(min_distances, max_min_idx)
+            # get minimum distance of unselected samples to that sample only
+            new_distances = np.min(ks_distance[:, [already_selected[-1]]], axis=1)
+            min_distances = np.minimum(min_distances, new_distances)
 
         self._samples_idxs = np.array(already_selected, dtype=int)


### PR DESCRIPTION
This PR dramatically improves the performance of the Kennard-Stone (and by consequence, the SPXY) sampler.

This new implementation makes a few major changes:
 - the list of indices which are selected already serves an additional purpose: masking the distance matrix to avoid us having to delete from the distance matrix
 - we only re-calculate the minimum distance of the unselected sample to the _new_ sample on each for loop iteration, which effectively reduces the runtime complexity by order N (to O(N^2))

The below code snippet is what I have been using to test, and `astartes` finishes in 3.7 seconds whereas `kennard_stone` takes 11 seconds (this also holds true for other size input arrays than the one here, this is on Python 3.7 with the latest version of kennard-stone installed from PyPI):
```python
import numpy as np
from kennard_stone import train_test_split as kennardstone_train_test_split
from astartes import train_test_split as astartes_train_test_split
example_X = np.random.rand(10_000, 100)
from time import perf_counter
start = perf_counter()
astartes_train_test_split(
    example_X,
    sampler="kennard_stone",
    hopts=dict(
        metric="euclidean",
    ),
)
stop = perf_counter()
print("astartes elapsed time: ", stop - start)
start = perf_counter()
kennardstone_train_test_split(
    example_X,
    metric="euclidean",
)
stop = perf_counter()
print("kennard_stone elapsed time: ", stop - start)
```