### PR TITLE
patch fixes for the previous patch fixes (version `1.1.2`)

### DIFF
--- a/.github/workflows/gen_docs.yml
+++ b/.github/workflows/gen_docs.yml
@@ -46,7 +46,7 @@ jobs:
           m2r README.md
           m2r CONTRIBUTING.md
           m2r sklearn_to_astartes.md
-          mv README.rst 
+          mv README.rst docs
           mv CONTRIBUTING.rst docs
           mv sklearn_to_astartes.rst docs
           cd docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ To contribute to the `astartes` source code, start by forking and then cloning t
 
 ### Version Checking
 
-`astartes` uses `pyproject.toml` to specify all metadata _except_ the version, which is specified in `astartes/__init__.py` (via `__version__`) for backwards compatibility with Python 3.7.
+`astartes` uses `pyproject.toml` to specify all metadata, but the version is also specified in `astartes/__init__.py` (via `__version__`) for backwards compatibility with Python 3.7.
 To check which version of `astartes` you have installed, you can run `python -c "import astartes; print(astartes.__version__)"` on Python 3.7 or `python -c "from importlib.metadata import version; version('astartes')" on Python 3.8 or newer.
 
 ### Testing

--- a/astartes/__init__.py
+++ b/astartes/__init__.py
@@ -1,7 +1,8 @@
 # convenience import to enable 'from astartes import train_test_split'
 from .main import train_test_split, train_val_test_split
 
-__version__ = "1.1.1"
+# update this in pyproject.toml, too
+__version__ = "1.1.2"
 
 # DO NOT do this:
 # from .molecules import train_test_split_molecules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astartes"
+# update this in astartes/__init__.py, too
+version = "1.1.2"
 authors = [
     { name = "Jackson Burns", email = "jwburns@mit.edu" },
     { name = "Himaghna Bhattacharjee", email = "himaghna@udel.edu" },
@@ -21,10 +23,6 @@ classifiers = [
 urls = { Homepage = "https://github.com/JacksonBurns/astartes" }
 requires-python = ">=3.7"
 dependencies = ["scikit_learn", "tabulate", "numpy", "scipy", "pandas"]
-dynamic = ["version"]
-
-[tool.setuptools.dynamic]
-version = { attr = "astartes.__version__" }
 
 [project.optional-dependencies]
 molecules = ["aimsim"]


### PR DESCRIPTION
The previous patches for pyOpenSci (#144) introduced some issues in the GitHub actions that we only saw once pushed to main - this PR fixes them. This also pushes the version to 1.1.2 for the reviewers to pyOpenSci.