### PR TITLE
Fix a bug with the definition of `max_shufflable_size`

### DIFF
--- a/astartes/main.py
+++ b/astartes/main.py
@@ -175,15 +175,22 @@ def _extrapolative_sampling(
         calls: return_helper
     """
     # calculate "goal" splitting sizes
-    n_test_samples = floor(len(sampler_instance.X) * test_size)
+    n_train_samples = floor(len(sampler_instance.X) * train_size)
     n_val_samples = floor(len(sampler_instance.X) * val_size)
+    n_test_samples = floor(len(sampler_instance.X) * test_size)
+
+    if val_size == 0:
+        max_shufflable_size=min(n_train_samples, n_test_samples)
+    else:
+        # typically, the test set and val set are smaller than the training set
+        max_shufflable_size=min(n_test_samples, n_val_samples)
     # unlike interpolative, cannot calculate n_train_samples here
     # since it will vary based on cluster_lengths
 
     # largest clusters must go into largest set, but smaller ones can optionally
     # be shuffled
     cluster_counter = sampler_instance.get_sorted_cluster_counter(
-        max_shufflable_size=min(n_test_samples, n_val_samples)
+        max_shufflable_size=max_shufflable_size
         if random_state is not None
         else None
     )


### PR DESCRIPTION
As pointed out in #163, many of our extrapolative samplers do not properly utilized the `random_state` when shuffling the indices. The issue comes from the previous definition of `max_shufflable_size=min(n_test_samples, n_val_samples)`. If `val_size=0`, such as when calling `train_test_split()`, the `max_shufflable_size` is the min of 0 (from `val_size`) and some positive number (from `test_size`). Since `max_shufflable_size` gets defined as 0 in this case, nothing is shuffled inside the `get_sorted_cluster_counter()` method, which is causing the behavior seen in #163 i.e., the random seed effectively isn't used. 

This commit fixes this issue by reassigning `max_shufflable_size` to be the min of train and test or val and test, depending on which is appropriate. I welcome feedback on alternative methods to address this. Looking forward to your thoughts!

