### PR TITLE
Fix Incorrectly Delayed Import in 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,17 @@ jobs:
             channel_priority: flexible
           create-args: |
             python=${{ matrix.python-version }}
-      - name: Install Dependencies
+      - name: Install Minimal Dependencies
+        run: |
+          python -m pip install -e .
+          python -m pip install coverage pytest
+      - name: Run Minimal Tests
+        run: |
+          coverage run --source=. --omit=astartes/__init__.py,setup.py,test/* -m pytest -v
+      - name: Install Molecules Dependencies
         run: |
           python -m pip install -e .[molecules]
-          python -m pip install coverage pytest
-      - name: Run Tests
+      - name: Run All Tests
         run: |
           coverage run --source=. --omit=astartes/__init__.py,setup.py,test/* -m pytest -v
       - name: Show Coverage

--- a/astartes/__init__.py
+++ b/astartes/__init__.py
@@ -1,7 +1,7 @@
 # convenience import to enable 'from astartes import train_test_split'
 from .main import train_test_split, train_val_test_split
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # DO NOT do this:
 # from .molecules import train_test_split_molecules

--- a/astartes/utils/aimsim_featurizer.py
+++ b/astartes/utils/aimsim_featurizer.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from astartes.utils.exceptions import MoleculesNotInstalledError
 
+Molecule = None
 try:
     """
     aimsim depends on sklearn_extra, which uses a version checking technique that is due to
@@ -16,7 +17,7 @@ try:
         from aimsim.chemical_datastructures import Molecule
         from aimsim.exceptions import LoadingError
 except ImportError:  # pragma: no cover
-    raise MoleculesNotInstalledError("""To use molecule featurizer, install astartes with pip install astartes[molecules].""")
+    pass  # Raise an error later
 
 
 def featurize_molecules(molecules, fingerprint, fprints_hopts):
@@ -30,6 +31,10 @@ def featurize_molecules(molecules, fingerprint, fprints_hopts):
     Returns:
         np.array: X array (featurized molecules)
     """
+    if Molecule is None:
+        raise MoleculesNotInstalledError(
+            """To use molecule featurizer, install astartes with pip install astartes[molecules] or conda install astartes aimsim."""
+        )
     X = []
     for molecule in molecules:
         try:

--- a/test/functional/test_molecules.py
+++ b/test/functional/test_molecules.py
@@ -4,20 +4,28 @@ import unittest
 import warnings
 
 import numpy as np
-from rdkit import Chem
 
-from astartes.molecules import (
-    train_test_split_molecules,
-    train_val_test_split_molecules,
-)
 from astartes.samplers import (
     DETERMINISTIC_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_EXTRAPOLATION_SAMPLERS,
     IMPLEMENTED_INTERPOLATION_SAMPLERS,
 )
-from astartes.utils.warnings import ImperfectSplittingWarning
+
+aimsim = None
+REASON = None
+try:
+    import aimsim
+    from rdkit import Chem
+
+    from astartes.molecules import (
+        train_test_split_molecules,
+        train_val_test_split_molecules,
+    )
+except ModuleNotFoundError:
+    REASON = "molecules subpackage not installed"
 
 
+@unittest.skipIf(aimsim is None, reason=REASON)
 class Test_molecules(unittest.TestCase):
     """
     Test the various functionalities of molecules.

--- a/test/unit/samplers/extrapolative/test_Scaffold.py
+++ b/test/unit/samplers/extrapolative/test_Scaffold.py
@@ -3,11 +3,21 @@ import unittest
 import numpy as np
 
 from astartes import train_test_split
-from astartes.samplers import Scaffold
 from astartes.utils.exceptions import InvalidConfigurationError
 from astartes.utils.warnings import NoMatchingScaffold
 
+aimsim = None
+REASON = None
+try:
+    # deliberately trigger an error if molecules subpackage missing
+    import aimsim
 
+    from astartes.samplers import Scaffold
+except ModuleNotFoundError:
+    REASON = "molecules subpackage not installed"
+
+
+@unittest.skipIf(aimsim is None, reason=REASON)
 class Test_scaffold(unittest.TestCase):
     """
     Test the various functionalities of Scaffold.

--- a/test/unit/samplers/extrapolative/test_molecular_weight.py
+++ b/test/unit/samplers/extrapolative/test_molecular_weight.py
@@ -3,9 +3,18 @@ import unittest
 import numpy as np
 
 from astartes import train_test_split
-from astartes.samplers import MolecularWeight
+
+aimsim = None
+REASON = None
+try:
+    import aimsim
+
+    from astartes.samplers import MolecularWeight
+except ModuleNotFoundError:
+    REASON = "molecules subpackage not installed"
 
 
+@unittest.skipIf(aimsim is None, reason=REASON)
 class Test_MolecularWeight(unittest.TestCase):
     """
     Test the various functionalities of MolecularWeight.


### PR DESCRIPTION
1.2.0 introduced an error in which the minimal installation no longer worked - this resolves that.