### PR TITLE
Change `aimsim` to `aimsim_core` for PyPI to lean out dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ We recommend installing `astartes` within a virtual environment, using either `v
 To install `astartes` with support for featurizing molecules, use: `conda install -c conda-forge astartes aimsim`.
 This will download the base `astartes` package as well as `aimsim`, which is the backend used for molecular featurization.
 
+The PyPI distribution has fewer dependencies for the `molecules` subpackage because it uses `aimsim_core` instead of `aimsim`.
+You can achieve this on `conda` by first running `conda install -c conda-forge astartes` and then `pip install aimsim_core` (`aimsim_core` is not available on `conda-forge`).
+
 ### Source
 To install `astartes` from source for development, see the [Contributing & Developer Notes](#contributing--developer-notes) section.
 

--- a/astartes/__init__.py
+++ b/astartes/__init__.py
@@ -1,7 +1,7 @@
 # convenience import to enable 'from astartes import train_test_split'
 from .main import train_test_split, train_val_test_split
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 # DO NOT do this:
 # from .molecules import train_test_split_molecules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.8"
 dependencies = ["scikit_learn", "tabulate", "numpy", "scipy", "pandas"]
 
 [project.optional-dependencies]
-molecules = ["aimsim"]
+molecules = ["aimsim_core"]
 dev = ["black", "isort", "pytest"]
 demos = ["plotly", "tabulate", "py2opsin", "kaleido"]
 


### PR DESCRIPTION
Ongoing development of leaner version of AIMSim here: https://github.com/VlachosGroup/AIMSim/pull/268